### PR TITLE
Add support 20 byte attributes for the nRF8001

### DIFF
--- a/nRF8001.cpp
+++ b/nRF8001.cpp
@@ -447,7 +447,7 @@ void nRF8001::begin(unsigned char advertisementDataType,
         setupMsgData->data[0] |= 0x20;
       }
 
-      setupMsgData->data[2]  = characteristic->valueSize();
+      setupMsgData->data[2]  = characteristic->valueSize() + 1;
       if (characteristic->fixedLength()) {
         setupMsgData->data[2]++;
       }
@@ -473,6 +473,17 @@ void nRF8001::begin(unsigned char advertisementDataType,
       gattSetupMsgOffset += 9 + characteristic->valueSize();
 
       this->sendSetupMessage(&setupMsg);
+
+
+        //This is where the insanity begins
+        setupMsgData->length   = 4;
+        setupMsgData->cmd      = ACI_CMD_SETUP;
+        setupMsgData->type     = 0x20;
+        setupMsgData->offset   = gattSetupMsgOffset++;
+        setupMsgData->data[0]  = 0x00;
+
+        this->sendSetupMessage(&setupMsg);
+        //and this is where things get back to normal
 
       if (characteristic->properties() & (BLENotify | BLEIndicate)) {
         setupMsgData->length   = 14;


### PR DESCRIPTION
Hi, I am working on emulating a device that uses 20byte characteristic values, and so I had to tweak the library to allow me to do that since I'm using a nRF8001 (a Blend Micro).  I just wanted to show what I did to get it working.  I did this by comparing your code with the existing service.h from the RBL example.  

This is clearly not mergable code, so please just close our the PR after you've had a look.