### PR TITLE
Add iBeacon support for nRF51.

### DIFF
--- a/BLECharacteristic.h
+++ b/BLECharacteristic.h
@@ -17,10 +17,10 @@ typedef void (*BLECharacteristicEventHandler)(BLECentral& central, BLECharacteri
 class BLECharacteristicValueChangeListener
 {
   public:
-    virtual bool characteristicValueChanged(BLECharacteristic& characteristic) = 0;
-    virtual bool broadcastCharacteristic(BLECharacteristic& characteristic) = 0;
-    virtual bool canNotifyCharacteristic(BLECharacteristic& characteristic) = 0;
-    virtual bool canIndicateCharacteristic(BLECharacteristic& characteristic) = 0;
+    virtual bool characteristicValueChanged(BLECharacteristic& characteristic) { }
+    virtual bool broadcastCharacteristic(BLECharacteristic& characteristic) { }
+    virtual bool canNotifyCharacteristic(BLECharacteristic& characteristic) { }
+    virtual bool canIndicateCharacteristic(BLECharacteristic& characteristic) { }
 };
 
 class BLECharacteristic : public BLELocalAttribute

--- a/BLEDevice.h
+++ b/BLEDevice.h
@@ -13,20 +13,20 @@ class BLEDevice;
 class BLEDeviceEventListener
 {
   public:
-    virtual void BLEDeviceConnected(BLEDevice& device, const unsigned char* address) = 0;
-    virtual void BLEDeviceDisconnected(BLEDevice& device) = 0;
-    virtual void BLEDeviceBonded(BLEDevice& device) = 0;
-    virtual void BLEDeviceRemoteServicesDiscovered(BLEDevice& device) = 0;
+    virtual void BLEDeviceConnected(BLEDevice& device, const unsigned char* address) { }
+    virtual void BLEDeviceDisconnected(BLEDevice& device) { }
+    virtual void BLEDeviceBonded(BLEDevice& device) { }
+    virtual void BLEDeviceRemoteServicesDiscovered(BLEDevice& device) { }
 
-    virtual void BLEDeviceCharacteristicValueChanged(BLEDevice& device, BLECharacteristic& characteristic, const unsigned char* value, unsigned char valueLength) = 0;
-    virtual void BLEDeviceCharacteristicSubscribedChanged(BLEDevice& device, BLECharacteristic& characteristic, bool subscribed) = 0;
+    virtual void BLEDeviceCharacteristicValueChanged(BLEDevice& device, BLECharacteristic& characteristic, const unsigned char* value, unsigned char valueLength) { }
+    virtual void BLEDeviceCharacteristicSubscribedChanged(BLEDevice& device, BLECharacteristic& characteristic, bool subscribed) { }
 
-    virtual void BLEDeviceRemoteCharacteristicValueChanged(BLEDevice& device, BLERemoteCharacteristic& remoteCharacteristic, const unsigned char* value, unsigned char valueLength) = 0;
+    virtual void BLEDeviceRemoteCharacteristicValueChanged(BLEDevice& device, BLERemoteCharacteristic& remoteCharacteristic, const unsigned char* value, unsigned char valueLength) { }
 
 
-    virtual void BLEDeviceAddressReceived(BLEDevice& device, const unsigned char* address) = 0;
-    virtual void BLEDeviceTemperatureReceived(BLEDevice& device, float temperature) = 0;
-    virtual void BLEDeviceBatteryLevelReceived(BLEDevice& device, float batteryLevel) = 0;
+    virtual void BLEDeviceAddressReceived(BLEDevice& device, const unsigned char* address) { }
+    virtual void BLEDeviceTemperatureReceived(BLEDevice& device, float temperature) { }
+    virtual void BLEDeviceBatteryLevelReceived(BLEDevice& device, float batteryLevel) { }
 };
 
 
@@ -54,30 +54,30 @@ class BLEDevice
                 BLELocalAttribute** localAttributes,
                 unsigned char numLocalAttributes,
                 BLERemoteAttribute** remoteAttributes,
-                unsigned char numRemoteAttributes) = 0;
+                unsigned char numRemoteAttributes) { }
 
-    virtual void poll() = 0;
+    virtual void poll() { }
 
-    virtual void startAdvertising() = 0;
-    virtual void disconnect() = 0;
+    virtual void startAdvertising() { }
+    virtual void disconnect() { }
 
-    virtual bool updateCharacteristicValue(BLECharacteristic& characteristic) = 0;
-    virtual bool broadcastCharacteristic(BLECharacteristic& characteristic) = 0;
-    virtual bool canNotifyCharacteristic(BLECharacteristic& characteristic) = 0;
-    virtual bool canIndicateCharacteristic(BLECharacteristic& characteristic) = 0;
+    virtual bool updateCharacteristicValue(BLECharacteristic& characteristic) { }
+    virtual bool broadcastCharacteristic(BLECharacteristic& characteristic) { }
+    virtual bool canNotifyCharacteristic(BLECharacteristic& characteristic) { }
+    virtual bool canIndicateCharacteristic(BLECharacteristic& characteristic) { }
 
-    virtual bool canReadRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool readRemoteCharacteristic(BLERemoteCharacteristic& remoteCharacteristic) = 0;
-    virtual bool canWriteRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool writeRemoteCharacteristic(BLERemoteCharacteristic& characteristic, const unsigned char value[], unsigned char length) = 0;
-    virtual bool canSubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool subscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool canUnsubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
+    virtual bool canReadRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool readRemoteCharacteristic(BLERemoteCharacteristic& remoteCharacteristic) { }
+    virtual bool canWriteRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool writeRemoteCharacteristic(BLERemoteCharacteristic& characteristic, const unsigned char value[], unsigned char length) { }
+    virtual bool canSubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool subscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool canUnsubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
 
-    virtual void requestAddress() = 0;
-    virtual void requestTemperature() = 0;
-    virtual void requestBatteryLevel() = 0;
+    virtual void requestAddress() { }
+    virtual void requestTemperature() { }
+    virtual void requestBatteryLevel() { }
 
   protected:
     unsigned short                _advertisingInterval;

--- a/BLEDeviceLimits.h
+++ b/BLEDeviceLimits.h
@@ -11,7 +11,7 @@
 #define min(a,b) (((a) < (b)) ? (a) : (b))
 #endif
 
-#ifdef NRF_51
+#ifdef NRF51
 
 #define BLE_ADVERTISEMENT_DATA_MAX_VALUE_LENGTH    26
 #define BLE_SCAN_DATA_MAX_VALUE_LENGTH             29

--- a/BLEHID.h
+++ b/BLEHID.h
@@ -20,8 +20,8 @@ class BLEHID
     void sendData(BLECharacteristic& characteristic, unsigned char data[], unsigned char dataLength);
 
     virtual void setReportId(unsigned char reportId);
-    virtual unsigned char numAttributes() = 0;
-    virtual BLELocalAttribute** attributes() = 0;
+    virtual unsigned char numAttributes() { }
+    virtual BLELocalAttribute** attributes() { }
 
   private:
     static unsigned char _numHids;

--- a/BLEPeripheral.h
+++ b/BLEPeripheral.h
@@ -47,6 +47,9 @@ class BLEPeripheral : public BLEDeviceEventListener,
     void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
     void setServiceSolicitationUuid(const char* serviceSolicitationUuid);
     void setManufacturerData(const unsigned char manufacturerData[], unsigned char manufacturerDataLength);
+#ifdef NRF51
+    void setIBeaconData(const char* iBeaconUuid, uint16_t iBeaconMajor, uint16_t iBeaconMinor, int8_t iBeaconMeasuredPower);
+#endif
     void setLocalName(const char *localName);
 
     void setAdvertisingInterval(unsigned short advertisingInterval);
@@ -113,6 +116,10 @@ class BLEPeripheral : public BLEDeviceEventListener,
     const char*                    _serviceSolicitationUuid;
     const unsigned char*           _manufacturerData;
     unsigned char                  _manufacturerDataLength;
+    const char*                    _iBeaconUuid;
+    uint16_t                       _iBeaconMajor;
+    uint16_t                       _iBeaconMinor;
+    int8_t                         _iBeaconMeasuredPower;
     const char*                    _localName;
 
     BLELocalAttribute**            _localAttributes;

--- a/BLERemoteCharacteristic.h
+++ b/BLERemoteCharacteristic.h
@@ -14,16 +14,16 @@ class BLERemoteCharacteristic;
 class BLERemoteCharacteristicValueChangeListener
 {
   public:
-    virtual bool canReadRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool readRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
+    virtual bool canReadRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool readRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
 
-    virtual bool canWriteRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool writeRemoteCharacteristic(BLERemoteCharacteristic& characteristic, const unsigned char value[], unsigned char length) = 0;
+    virtual bool canWriteRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool writeRemoteCharacteristic(BLERemoteCharacteristic& characteristic, const unsigned char value[], unsigned char length) { }
 
-    virtual bool canSubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool subscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool canUnsubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
-    virtual bool unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) = 0;
+    virtual bool canSubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool subscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool canUnsubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
+    virtual bool unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) { }
 };
 
 typedef void (*BLERemoteCharacteristicEventHandler)(BLECentral& central, BLERemoteCharacteristic& characteristic);

--- a/examples/ibeacon/ibeacon.ino
+++ b/examples/ibeacon/ibeacon.ino
@@ -7,40 +7,13 @@
 
 static BLEPeripheral blePeripheral(0, 0, 0);
 
-static unsigned char manufacturerData[MAX_UUID_LENGTH + 9]; // 4 bytes of header and 5 bytes of trailer.
-
-static void setIBeaconData(BLEPeripheral& peripheral, const char* uuidString, uint16_t major, uint16_t minor, int8_t measuredPower) {
-  BLEUuid uuid(uuidString);
-  int i = 0;
-
-  // 0x004c = Apple, see https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers
-  manufacturerData[i++] = 0x4c; // Apple Company Identifier LE (16 bit)
-  manufacturerData[i++] = 0x00;
-  
-  // See "Beacon type" in "Building Applications with IBeacon".
-  manufacturerData[i++] = 0x02;
-  manufacturerData[i++] = uuid.length() + 5;
-
-  for (int j = (uuid.length() - 1); j >= 0; j--) {
-    manufacturerData[i++] = uuid.data()[j];
-  }
-
-  manufacturerData[i++] = major >> 8;
-  manufacturerData[i++] = major;
-  manufacturerData[i++] = minor >> 8;
-  manufacturerData[i++] = minor;
-  manufacturerData[i++] = measuredPower;
-
-  blePeripheral.setManufacturerData(manufacturerData, i);
-}
-
 void setup() {
   char* uuidString = "a196c876-de8c-4c47-ab5a-d7afd5ae7127";
   uint16_t major = 0;
   uint16_t minor = 0;
   int8_t measuredPower = -55;
   
-  setIBeaconData(blePeripheral, uuidString, major, minor, measuredPower);
+  blePeripheral.setIBeaconData(uuidString, major, minor, measuredPower);
 
   blePeripheral.begin();
 }

--- a/examples/ibeacon/ibeacon.ino
+++ b/examples/ibeacon/ibeacon.ino
@@ -1,0 +1,50 @@
+#include <BLEPeripheral.h>
+#include <BLEUuid.h>
+
+#ifndef NRF51
+#error "This example only works with nRF51 boards"
+#endif
+
+static BLEPeripheral blePeripheral(0, 0, 0);
+
+static unsigned char manufacturerData[MAX_UUID_LENGTH + 9]; // 4 bytes of header and 5 bytes of trailer.
+
+static void setIBeaconData(BLEPeripheral& peripheral, const char* uuidString, uint16_t major, uint16_t minor, int8_t measuredPower) {
+  BLEUuid uuid(uuidString);
+  int i = 0;
+
+  // 0x004c = Apple, see https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers
+  manufacturerData[i++] = 0x4c; // Apple Company Identifier LE (16 bit)
+  manufacturerData[i++] = 0x00;
+  
+  // See "Beacon type" in "Building Applications with IBeacon".
+  manufacturerData[i++] = 0x02;
+  manufacturerData[i++] = uuid.length() + 5;
+
+  for (int j = (uuid.length() - 1); j >= 0; j--) {
+    manufacturerData[i++] = uuid.data()[j];
+  }
+
+  manufacturerData[i++] = major >> 8;
+  manufacturerData[i++] = major;
+  manufacturerData[i++] = minor >> 8;
+  manufacturerData[i++] = minor;
+  manufacturerData[i++] = measuredPower;
+
+  blePeripheral.setManufacturerData(manufacturerData, i);
+}
+
+void setup() {
+  char* uuidString = "a196c876-de8c-4c47-ab5a-d7afd5ae7127";
+  uint16_t major = 0;
+  uint16_t minor = 0;
+  int8_t measuredPower = -55;
+  
+  setIBeaconData(blePeripheral, uuidString, major, minor, measuredPower);
+
+  blePeripheral.begin();
+}
+
+void loop() {
+  blePeripheral.poll();
+}


### PR DESCRIPTION
The advertisement data length limits of the nRF8001 mean it can't support iBeacon.

However the nRF51 can, so I've added iBeacon support for it to BLEPeripheral.

There are four commits in this pull request:

1. A tiny correction to `BLEDeviceLimits.h` - the `NRF51` macro name was incorrect so the nRF8001 data length limits were being used for the nRF51.
2. A new example, in `example/ibeacon`, that demonstrates setting up the manufacturer data (directly in the example code itself) so that the board advertises itself as an iBeacon.
3. In this commit I moved this logic from the example into `BLEPeripheral`, adding a new method called `setIBeaconData`.
4. Changed all the pure virtual methods to instead be virtual methods with empty method implementations.

The last commit is unrelated to the iBeacon logic. I tried to submit it as a separate pull request but GitHub just coalesces new commits into any already open pull request. I've added a separate section below explaining why I did this.

Notes:

* As I hate polluting code with tons of `#ifdef`statements I only added `NRF51` checks around the `setIBeaconData` declaration and definition, while leaving the new member variables alone. However this does mean everyone ends up getting these member variables even if, as on an nRF8001 board, they can't use them.
* I don't have an RFduino so I only enabled these changes using the `NRF51` macro. I'm sure this new logic will work for the RFduino but I can't test that - so for the moment RFduino users get the old existing behavior.

---

## Why pure virtuals impose a high cost

Why did I change the pure virtual methods to all have useless empty implementations? Because using pure virtual methods results in a surprisingly high fixed additional size cost.

For my BLE Nano my tiny iBeacon example takes up 48K, while the corresponding iBeacon example from RBL takes up just 15K. This is not specific to the new iBeacon logic but is a general issue - eliminating the pure virtual functions results in the size shrinking to less than that of the RBL example :smiley:

This is because the use of even a single pure virtual function pulls in the [`__cxa_pure_virtual`](http://stackoverflow.com/questions/920500/what-is-the-purpose-of-cxa-pure-virtual) function. This function isn't large in itself but it pulls in a whole load of C++ name demangling functionality and `printf` related functions. So `__cxa_pure_virtual` pulls in more than 30KB or extra code - a trivial amount for most people but huge in our context.

The `__cxa_pure_virtual` functionality only actually kicks in if you try to do something stupid, like calling a pure virtual from a constructor (before its been wired up). So if your code is correct it's never actually used.

An alternative to not using pure virtual functions is to provide your own light weight `__cxa_pure_virtual` implementation, e.g.:

    extern "C" void __cxa_pure_virtual() { abort(); }

This won't clash with the default system implementation, however it has issues when using the Arduino IDE. You can't leave it up to individual developers to add it to their `.ino` files as the mangling that the Arduino IDE does (providing forward declarations for all functions etc.) can't handle `extern "C"` (the resulting error is very non-intuitive). And adding it into a library doesn't seem like a good idea either as it will clash if the user has already decided to do the same thing themselves in some other non `.ino` code.

---
PS Sandeep - your BLE projects for Arduino and Node have been a great help to me - thanks I really appreciate all the work you've put into everything :smiley: