### PR TITLE
Add new iBeacon class for nRF51 boards.

### DIFF
--- a/examples/ibeacon/ibeacon.ino
+++ b/examples/ibeacon/ibeacon.ino
@@ -1,5 +1,5 @@
 #include <BLEPeripheral.h>
-#include <BLEUuid.h>
+#include <iBeacon.h>
 
 #if !defined(NRF51) && !defined(__RFduino__)
 #error "This example only works with nRF51 boards"
@@ -7,39 +7,13 @@
 
 static BLEPeripheral blePeripheral(0, 0, 0);
 
-static void setIBeaconData(BLEPeripheral& peripheral, const char* uuidString, uint16_t major, uint16_t minor, int8_t measuredPower) {
-  unsigned char manufacturerData[MAX_UUID_LENGTH + 9]; // 4 bytes of header and 5 bytes of trailer.
-  BLEUuid uuid(uuidString);
-  int i = 0;
-
-  // 0x004c = Apple, see https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers
-  manufacturerData[i++] = 0x4c; // Apple Company Identifier LE (16 bit)
-  manufacturerData[i++] = 0x00;
-
-  // See "Beacon type" in "Building Applications with IBeacon".
-  manufacturerData[i++] = 0x02;
-  manufacturerData[i++] = uuid.length() + 5;
-
-  for (int j = (uuid.length() - 1); j >= 0; j--) {
-    manufacturerData[i++] = uuid.data()[j];
-  }
-
-  manufacturerData[i++] = major >> 8;
-  manufacturerData[i++] = major;
-  manufacturerData[i++] = minor >> 8;
-  manufacturerData[i++] = minor;
-  manufacturerData[i++] = measuredPower;
-
-  peripheral.setManufacturerData(manufacturerData, i);
-}
-
 void setup() {
-  char* uuidString = "a196c876-de8c-4c47-ab5a-d7afd5ae7127";
+  char* uuid = "a196c876-de8c-4c47-ab5a-d7afd5ae7127";
   uint16_t major = 0;
   uint16_t minor = 0;
   int8_t measuredPower = -55;
-
-  setIBeaconData(blePeripheral, uuidString, major, minor, measuredPower);
+  
+  iBeacon::setData(blePeripheral, uuid, major, minor, measuredPower);
 
   blePeripheral.begin();
 }

--- a/examples/ibeacon/ibeacon.ino
+++ b/examples/ibeacon/ibeacon.ino
@@ -1,0 +1,49 @@
+#include <BLEPeripheral.h>
+#include <BLEUuid.h>
+
+#if !defined(NRF51) && !defined(__RFduino__)
+#error "This example only works with nRF51 boards"
+#endif
+
+static BLEPeripheral blePeripheral(0, 0, 0);
+
+static void setIBeaconData(BLEPeripheral& peripheral, const char* uuidString, uint16_t major, uint16_t minor, int8_t measuredPower) {
+  unsigned char manufacturerData[MAX_UUID_LENGTH + 9]; // 4 bytes of header and 5 bytes of trailer.
+  BLEUuid uuid(uuidString);
+  int i = 0;
+
+  // 0x004c = Apple, see https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers
+  manufacturerData[i++] = 0x4c; // Apple Company Identifier LE (16 bit)
+  manufacturerData[i++] = 0x00;
+
+  // See "Beacon type" in "Building Applications with IBeacon".
+  manufacturerData[i++] = 0x02;
+  manufacturerData[i++] = uuid.length() + 5;
+
+  for (int j = (uuid.length() - 1); j >= 0; j--) {
+    manufacturerData[i++] = uuid.data()[j];
+  }
+
+  manufacturerData[i++] = major >> 8;
+  manufacturerData[i++] = major;
+  manufacturerData[i++] = minor >> 8;
+  manufacturerData[i++] = minor;
+  manufacturerData[i++] = measuredPower;
+
+  peripheral.setManufacturerData(manufacturerData, i);
+}
+
+void setup() {
+  char* uuidString = "a196c876-de8c-4c47-ab5a-d7afd5ae7127";
+  uint16_t major = 0;
+  uint16_t minor = 0;
+  int8_t measuredPower = -55;
+
+  setIBeaconData(blePeripheral, uuidString, major, minor, measuredPower);
+
+  blePeripheral.begin();
+}
+
+void loop() {
+  blePeripheral.poll();
+}

--- a/iBeacon.cpp
+++ b/iBeacon.cpp
@@ -1,0 +1,33 @@
+#if defined(NRF51) || defined(__RFduino__)
+
+#include <BLEUuid.h>
+
+#include "iBeacon.h"
+
+void iBeacon::setData(BLEPeripheral& peripheral, const char* uuidString, uint16_t major, uint16_t minor, int8_t measuredPower) {
+  unsigned char manufacturerData[MAX_UUID_LENGTH + 9]; // 4 bytes of header and 5 bytes of trailer.
+  BLEUuid uuid(uuidString);
+  int i = 0;
+
+  // 0x004c = Apple, see https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers
+  manufacturerData[i++] = 0x4c; // Apple Company Identifier LE (16 bit)
+  manufacturerData[i++] = 0x00;
+  
+  // See "Beacon type" in "Building Applications with IBeacon".
+  manufacturerData[i++] = 0x02;
+  manufacturerData[i++] = uuid.length() + 5;
+
+  for (int j = (uuid.length() - 1); j >= 0; j--) {
+    manufacturerData[i++] = uuid.data()[j];
+  }
+
+  manufacturerData[i++] = major >> 8;
+  manufacturerData[i++] = major;
+  manufacturerData[i++] = minor >> 8;
+  manufacturerData[i++] = minor;
+  manufacturerData[i++] = measuredPower;
+
+  peripheral.setManufacturerData(manufacturerData, i);
+}
+
+#endif

--- a/iBeacon.h
+++ b/iBeacon.h
@@ -1,0 +1,16 @@
+#ifndef _I_BEACON_H_
+#define _I_BEACON_H_
+
+#if defined(NRF51) || !defined(__RFduino__)
+
+#include "BLEPeripheral.h"
+
+class iBeacon
+{
+  public:
+    static void setData(BLEPeripheral& peripheral, const char* uuidString, uint16_t major, uint16_t minor, int8_t measuredPower);
+};
+
+#endif
+
+#endif


### PR DESCRIPTION
As you suggested I created a new iBeacon class rather than putting the iBeacon logic into BLEPeripheral.

Unlike URIBeacon I don't wrap BLEPeripheral and then provide lots of methods to delegate to it.

Instead I've just provided a single class method that sets up a BLEPeripheral appropriately. Not very OO-ish but for such a simple self-contained piece of logic I thought all the extra delegation boilerplate would make it look way more complex than it it.

The [ibeacon.ino](https://github.com/sandeepmistry/arduino-BLEPeripheral/blob/6d906beffe7dbcc78cdeed1cfae4811758ecfda8/examples/ibeacon/ibeacon.ino) shows how little there is to using it.

I've tested this with the RBL BLE Nano and also tested that everything compiles without complaint if `NRF51` and `__RFduino__` are _not_ set, but I don't have an RFduino to test with (I presume things should work fine with it).