### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Sandeep Mistry <sandeep.mistry@gmail.com>
 maintainer=Sandeep Mistry <sandeep.mistry@gmail.com>
 sentence=An Arduino library for creating custom BLE peripherals.
 paragraph=Supports nRF8001 and nRF51822 based boards/shields
+category=Communication
 url=https://github.com/sandeepmistry/arduino-BLEPeripheral
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library BLEPeripheral is not valid.
Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.