### PR TITLE
Only discover remote services if we need them.

### DIFF
--- a/nRF51822.cpp
+++ b/nRF51822.cpp
@@ -446,7 +446,9 @@ void nRF51822::poll() {
           this->_eventListener->BLEDeviceConnected(*this, bleEvt->evt.gap_evt.params.connected.peer_addr.addr);
         }
 
-        sd_ble_gattc_primary_services_discover(this->_connectionHandle, 1, NULL);
+        if (this->_numRemoteServices > 0) {
+          sd_ble_gattc_primary_services_discover(this->_connectionHandle, 1, NULL);
+        }
         break;
 
       case BLE_GAP_EVT_DISCONNECTED:


### PR DESCRIPTION
At the moment remote service discovery is always triggered when a central device connects.

However nothing will actually happen in the `BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP` logic if `_numRemoteServices` is zero:
```c++
case BLE_GATTC_EVT_PRIM_SRVC_DISC_RSP:
    ...
    for (int j = 0; j < this->_numRemoteServices; j++) {
```

`_numRemoteServices` is only non-zero if the end user called `BLEPeripheral::addRemoteAttribute(...)` at least once with a remote attribute of type `BLETypeService`.

So I've added a one line check to just call `sd_ble_gattc_primary_services_discover(...)` if `_numRemoteServices` is greater than zero.