### PR TITLE
PlatformIO Library Manager Support

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,5 +8,5 @@
     "url": "https://github.com/sandeepmistry/arduino-BLEPeripheral.git"
   },
   "frameworks": "arduino",
-  "platforms": "nordicnrf51, atmelavr, teensy"
+  "platforms": "nordicnrf51, atmelavr, atmelsam, teensy"
 }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,12 @@
+{
+  "name": "BLEPeripheral",
+  "keywords": "BLE, bluetooth, peripheral",
+  "description": "Arduino library for creating custom BLE peripherals. Supports nRF8001 and nRF51822 based boards/shields.",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/sandeepmistry/arduino-BLEPeripheral.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "nordicnrf51, atmelavr, teensy"
+}


### PR DESCRIPTION
I recently switched my embedded project to [PlatformIO Build System](http://platformio.org). The killer  feature of PlatformIO is it's neat [library management system](http://docs.platformio.org/en/latest/librarymanager/index.html) and I wasn't able to find my favorite BLE library and install it :)

I'd like to fix it so I followed the [documentation](http://docs.platformio.org/en/latest/librarymanager/creating.html) and created a simple `library.json` file. If this pull request is merged `BLEPeripheral` library can be registered into PlatformIO database by running:
```bash
$ platformio lib register https://raw.githubusercontent.com/sandeepmistry/arduino-BLEPeripheral/master/library.json
```