### PR TITLE
Reduce SRAM consumption of serial.ino example

### DIFF
--- a/examples/serial/BLESerial.h
+++ b/examples/serial/BLESerial.h
@@ -28,7 +28,7 @@ class BLESerial : public BLEPeripheral, public Stream
     size_t _rxHead;
     size_t _rxTail;
     size_t _rxCount() const;
-    uint8_t _rxBuffer[256];
+    uint8_t _rxBuffer[BLE_ATTRIBUTE_MAX_VALUE_LENGTH];
     size_t _txCount;
     uint8_t _txBuffer[BLE_ATTRIBUTE_MAX_VALUE_LENGTH];
 


### PR DESCRIPTION
Make the `serial.ino` example sketch runnable on _Arduino Uno_ with _nRF8001_. Should help with issue #82.