### PR TITLE
Bondstore (clear/put) functional for s130 and s132 using the softdevice API

### DIFF
--- a/src/BLEBondStore.cpp
+++ b/src/BLEBondStore.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) Sandeep Mistry. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+// Contributors:
+//    Bosch Software Innovations GmbH - Please refer to git log
+
 
 #ifdef __AVR__
   #include <avr/eeprom.h>

--- a/src/BLEBondStore.cpp
+++ b/src/BLEBondStore.cpp
@@ -1,8 +1,5 @@
 // Copyright (c) Sandeep Mistry. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
-// Contributors:
-//    Bosch Software Innovations GmbH - Please refer to git log
 
 
 #ifdef __AVR__
@@ -41,13 +38,11 @@ void BLEBondStore::clearData() {
   eeprom_write_byte((unsigned char *)this->_offset, 0x00);
 #elif defined(NRF51) || defined(NRF52) || defined(__RFduino__)
 
-//uint32_t us = micros();
   int32_t pageNo = (uint32_t)_flashPageStartAddress/NRF_FICR->CODEPAGESIZE;
   uint32_t err_code;
   do {
 	err_code = sd_flash_page_erase(pageNo);
   } while(err_code == NRF_ERROR_BUSY);
-//Serial.print("BLEBondStore::clearData()[us]:"); Serial.println(micros()-us); // nrf51: 26116us nrf52: 2655us!
 #endif
 }
 
@@ -61,12 +56,10 @@ void BLEBondStore::putData(const unsigned char* data, unsigned int offset, unsig
 #elif defined(NRF51) || defined(NRF52) || defined(__RFduino__) // ignores offset
   this->clearData();
 
-//uint32_t us = micros();
   uint32_t err_code;
   do {
 	  err_code = sd_flash_write((uint32_t*)_flashPageStartAddress, (uint32_t*)data, (uint32_t)length/4);
   } while(err_code == NRF_ERROR_BUSY);
-//Serial.print("BLEBondStore::putData()[us]:"); Serial.println(micros()-us);	// nrf51:40832us nrf52:95031us!
 #endif
 }
 

--- a/src/BLEBondStore.cpp
+++ b/src/BLEBondStore.cpp
@@ -4,8 +4,13 @@
 
 #ifdef __AVR__
   #include <avr/eeprom.h>
-#elif defined(NRF51) || defined(NRF52) || defined(__RFduino__)
-  #include "nrf_soc.h"
+#elif defined(__RFduino__)
+  #include <utility/RFduino/nrf_soc.h>
+#define FLASH_WAIT_READY { \
+  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {}; \
+}
+#elif defined(NRF51) || defined(NRF52)
+  #include <nrf_soc.h>
 #else
   #warning "BLEBondStore persistent storage not supported on this platform"
 #endif
@@ -36,13 +41,34 @@ bool BLEBondStore::hasData() {
 void BLEBondStore::clearData() {
 #if defined(__AVR__) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
   eeprom_write_byte((unsigned char *)this->_offset, 0x00);
-#elif defined(NRF51) || defined(NRF52) || defined(__RFduino__)
+#elif defined(NRF51) || defined(NRF52)
 
   int32_t pageNo = (uint32_t)_flashPageStartAddress/NRF_FICR->CODEPAGESIZE;
   uint32_t err_code;
   do {
 	err_code = sd_flash_page_erase(pageNo);
   } while(err_code == NRF_ERROR_BUSY);
+
+#elif defined(__RFduino__)
+
+  // turn on flash erase enable
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Een << NVMC_CONFIG_WEN_Pos);
+
+  // wait until ready
+  FLASH_WAIT_READY
+
+  // erase page
+  NRF_NVMC->ERASEPAGE = (uint32_t)this->_flashPageStartAddress;
+
+  // wait until ready
+  FLASH_WAIT_READY
+
+  // turn off flash erase enable
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+
+  // wait until ready
+  FLASH_WAIT_READY
+
 #endif
 }
 
@@ -53,13 +79,43 @@ void BLEBondStore::putData(const unsigned char* data, unsigned int offset, unsig
   for (unsigned int i = 0; i < length; i++) {
     eeprom_write_byte((unsigned char *)this->_offset + offset + i + 1, data[i]);
   }
-#elif defined(NRF51) || defined(NRF52) || defined(__RFduino__) // ignores offset
+#elif defined(NRF51) || defined(NRF52)  // ignores offset
   this->clearData();
 
   uint32_t err_code;
   do {
 	  err_code = sd_flash_write((uint32_t*)_flashPageStartAddress, (uint32_t*)data, (uint32_t)length/4);
   } while(err_code == NRF_ERROR_BUSY);
+
+#elif defined(__RFduino__) // ignores offset
+
+  this->clearData();
+
+  // turn on flash write enable
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
+
+  // wait until ready
+  FLASH_WAIT_READY
+
+  uint32_t *out = this->_flashPageStartAddress;
+  uint32_t *in  = (uint32_t*)data;
+
+  for(unsigned char i = 0; i < length; i += 4) { // assumes length is multiple of 4
+    *out = *in;
+
+    out++;
+    in++;
+  }
+
+  // wait until ready
+  FLASH_WAIT_READY
+
+  // turn off flash write enable
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+
+  // wait until ready
+  FLASH_WAIT_READY
+
 #endif
 }
 

--- a/src/BLEBondStore.cpp
+++ b/src/BLEBondStore.cpp
@@ -4,7 +4,7 @@
 #ifdef __AVR__
   #include <avr/eeprom.h>
 #elif defined(NRF51) || defined(NRF52) || defined(__RFduino__)
-  // nothing extra needed
+  #include "nrf_soc.h"
 #else
   #warning "BLEBondStore persistent storage not supported on this platform"
 #endif
@@ -12,10 +12,6 @@
 #include "Arduino.h"
 
 #include "BLEBondStore.h"
-
-#if defined(NRF51) || defined(NRF52) || defined(__RFduino__)
-#include "nrf_soc.h"
-#endif
 
 BLEBondStore::BLEBondStore(int offset)
 #if defined(__AVR__) || defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MKL26Z64__)
@@ -41,25 +37,13 @@ void BLEBondStore::clearData() {
   eeprom_write_byte((unsigned char *)this->_offset, 0x00);
 #elif defined(NRF51) || defined(NRF52) || defined(__RFduino__)
 
-//  uint32_t us = micros();
+//uint32_t us = micros();
   int32_t pageNo = (uint32_t)_flashPageStartAddress/NRF_FICR->CODEPAGESIZE;
   uint32_t err_code;
   do {
 	err_code = sd_flash_page_erase(pageNo);
   } while(err_code == NRF_ERROR_BUSY);
-//  Serial.print("BLEBondStore::clearData()[us]:"); Serial.println(micros()-us); // nrf51: 26116us nrf52: 2655us!
-//  switch(err_code) {
-//  // @retval ::NRF_ERROR_INVALID_ADDR   Tried to write to a non existing flash address, or p_dst or p_src was unaligned.
-//  // @retval ::NRF_ERROR_BUSY           The previous command has not yet completed.
-//  // @retval ::NRF_ERROR_INVALID_LENGTH Size was 0, or higher than the maximum allowed size.
-//  // @retval ::NRF_ERROR_FORBIDDEN      Tried to write to or read from protected location.
-//  // @retval ::NRF_SUCCESS              The command was accepted.
-//  case NRF_ERROR_INTERNAL: 	 	Serial.println("clearData: NRF_ERROR_INTERNAL");  	break;
-//  case NRF_ERROR_INVALID_ADDR:	Serial.println("clearData: NRF_ERROR_INVALID_ADDR");break;
-//  case NRF_ERROR_BUSY: 		 	Serial.println("clearData: NRF_ERROR_BUSY");		break; 
-//  case NRF_ERROR_FORBIDDEN: 		Serial.println("clearData: NRF_ERROR_FORBIDDEN"); 	break;
-//  default:				     	Serial.println("clearData: NRF_SUCCESS!!");			break;
-//  }
+//Serial.print("BLEBondStore::clearData()[us]:"); Serial.println(micros()-us); // nrf51: 26116us nrf52: 2655us!
 #endif
 }
 
@@ -73,24 +57,12 @@ void BLEBondStore::putData(const unsigned char* data, unsigned int offset, unsig
 #elif defined(NRF51) || defined(NRF52) || defined(__RFduino__) // ignores offset
   this->clearData();
 
-//  uint32_t us = micros();
+//uint32_t us = micros();
   uint32_t err_code;
   do {
 	  err_code = sd_flash_write((uint32_t*)_flashPageStartAddress, (uint32_t*)data, (uint32_t)length/4);
   } while(err_code == NRF_ERROR_BUSY);
-//  Serial.print("BLEBondStore::putData()[us]:"); Serial.println(micros()-us);	// nrf51:40832us nrf52:95031us!
-//  switch(err_code) {
-//  // @retval ::NRF_ERROR_INVALID_ADDR   Tried to write to a non existing flash address, or p_dst or p_src was unaligned.
-//  // @retval ::NRF_ERROR_BUSY           The previous command has not yet completed.
-//  // @retval ::NRF_ERROR_INVALID_LENGTH Size was 0, or higher than the maximum allowed size.
-//  // @retval ::NRF_ERROR_FORBIDDEN      Tried to write to or read from protected location.
-//  // @retval ::NRF_SUCCESS              The command was accepted.
-//  case NRF_ERROR_INTERNAL: 	 	Serial.println("putData: NRF_ERROR_INTERNAL");  	break;
-//  case NRF_ERROR_INVALID_ADDR:	Serial.println("putData: NRF_ERROR_INVALID_ADDR");	break;
-//  case NRF_ERROR_BUSY: 		 	Serial.println("putData: NRF_ERROR_BUSY");			break; 
-//  case NRF_ERROR_FORBIDDEN: 		Serial.println("putData: NRF_ERROR_FORBIDDEN"); 	break;
-//  default:				     	Serial.println("putData: NRF_SUCCESS!!");			break;
-//  }
+//Serial.print("BLEBondStore::putData()[us]:"); Serial.println(micros()-us);	// nrf51:40832us nrf52:95031us!
 #endif
 }
 


### PR DESCRIPTION
Replacing the nativ nvmc functions approach for clearing an writing internal bondstore memory by using softdevice functions does enable bondstore using for s130 and s132 . This PR is testet against S132 for nRF52-DK board and S130 for the Generic-nRF51822-32k (on nRF51422-DK) and RedBearLab-nRF51822 boards. For the older softdevice s110 on RBL-nRF51822, it does not work really, because the library does write allways 0x00 bytes for the bondstore key - also with the previous/current implementation and seems to be a different issue.