### PR TITLE
fix compile issues for debug defines

### DIFF
--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) Sandeep Mistry. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+// Contributors:
+//    Bosch Software Innovations GmbH - Please refer to git log
+
 
 #include "BLEUuid.h"
 
@@ -361,7 +365,7 @@ void BLEPeripheral::BLEDeviceRemoteCharacteristicValueChanged(BLEDevice& /*devic
   remoteCharacteristic.setValue(this->_central, value, valueLength);
 }
 
-void BLEPeripheral::BLEDeviceAddressReceived(BLEDevice& /*device*/, const unsigned char* /*address*/) {
+void BLEPeripheral::BLEDeviceAddressReceived(BLEDevice& /*device*/, const unsigned char* address) {
 #ifdef BLE_PERIPHERAL_DEBUG
   char addressStr[18];
 

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -1,5 +1,8 @@
 // Copyright (c) Sandeep Mistry. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+// Contributors:
+//    Bosch Software Innovations GmbH - Please refer to git log
 
 #if defined(NRF51) || defined(NRF52) || defined(__RFduino__)
 
@@ -621,10 +624,6 @@ void nRF51822::poll() {
       case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
 #ifdef NRF_51822_DEBUG
         Serial.print(F("Evt Sec Params Request "));
-#if !defined(NRF51_S130) && !defined(S110)
-        Serial.print(bleEvt->evt.gap_evt.params.sec_params_request.peer_params.timeout);
-        Serial.print(F(" "));
-#endif
         Serial.print(bleEvt->evt.gap_evt.params.sec_params_request.peer_params.bond);
         Serial.print(F(" "));
         Serial.print(bleEvt->evt.gap_evt.params.sec_params_request.peer_params.mitm);


### PR DESCRIPTION
Compile issue using NRF_51822_DEBUG in nRF51822.cpp:
bleEvt->evt.gap_evt.params.sec_params_request.peer_params.timeout 
is not a part of the ble_gap_sec_params_t structure in ble_gatt.h 
for all used softdevices s132, s130 (SDK_11), and s110 (SDK_8)
Compile issue using BLE_PERIPHERAL_DEBUG in BLEPeripheral.cpp:
printing the address parameter in function.