### PR TITLE
Advertise multiple services and different data types

### DIFF
--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -57,9 +57,9 @@ class BLEDevice
     void setBondStore(BLEBondStore& bondStore);
 
     virtual void begin(unsigned char /*advertisementDataSize*/,
-                BLEEirData * /*advertisementData*/,
+                unsigned char * /*advertisementData*/,
                 unsigned char /*scanDataSize*/,
-                BLEEirData * /*scanData*/,
+                unsigned char * /*scanData*/,
                 BLELocalAttribute** /*localAttributes*/,
                 unsigned char /*numLocalAttributes*/,
                 BLERemoteAttribute** /*remoteAttributes*/,

--- a/src/BLEDeviceLimits.h
+++ b/src/BLEDeviceLimits.h
@@ -18,7 +18,7 @@
 
 #endif
 
-#if defined(NRF51) || defined(__RFduino__)
+#if defined(NRF51) || defined(__RFduino__) || defined(NRF52)
 
 #define BLE_ADVERTISEMENT_DATA_MAX_VALUE_LENGTH    26
 #define BLE_SCAN_DATA_MAX_VALUE_LENGTH             29

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -121,6 +121,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
   private:
     void initLocalAttributes();
+    void addFieldInPck(uint8_t type, uint8_t len, unsigned char* data);
 
   private:
     BLEDevice*                     _device;
@@ -131,11 +132,10 @@ class BLEPeripheral : public BLEDeviceEventListener,
     nRF8001                        _nRF8001;
 #endif
 
-    const char*                    _advertisedServiceUuid;
-    const char*                    _serviceSolicitationUuid;
-    const unsigned char*           _manufacturerData;
-    unsigned char                  _manufacturerDataLength;
-    const char*                    _localName;
+    unsigned char                  _advData[32];
+    uint8_t                        _advDataLength=0;
+    unsigned char                  _scanData[32];
+    uint8_t                        _scanDataLength=0;
 
     BLELocalAttribute**            _localAttributes;
     unsigned char                  _numLocalAttributes;

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -77,9 +77,9 @@ nRF51822::~nRF51822() {
 }
 
 void nRF51822::begin(unsigned char advertisementDataSize,
-                      BLEEirData *advertisementData,
+                      unsigned char *advertisementData,
                       unsigned char scanDataSize,
-                      BLEEirData *scanData,
+                      unsigned char *scanData,
                       BLELocalAttribute** localAttributes,
                       unsigned char numLocalAttributes,
                       BLERemoteAttribute** remoteAttributes,
@@ -182,43 +182,10 @@ void nRF51822::begin(unsigned char advertisementDataSize,
   sd_ble_gap_ppcp_set(&gap_conn_params);
   sd_ble_gap_tx_power_set(0);
 
-  unsigned char srData[31];
-  unsigned char srDataLen = 0;
+  memcpy(&this->_advData, advertisementData, advertisementDataSize);
+  this->_advDataLen=advertisementDataSize;
 
-  this->_advDataLen = 0;
-
-  // flags
-  this->_advData[this->_advDataLen + 0] = 2;
-  this->_advData[this->_advDataLen + 1] = 0x01;
-  this->_advData[this->_advDataLen + 2] = 0x06;
-
-  this->_advDataLen += 3;
-
-  if (advertisementDataSize && advertisementData) {
-    for (int i = 0; i < advertisementDataSize; i++) {
-      this->_advData[this->_advDataLen + 0] = advertisementData[i].length + 1;
-      this->_advData[this->_advDataLen + 1] = advertisementData[i].type;
-      this->_advDataLen += 2;
-
-      memcpy(&this->_advData[this->_advDataLen], advertisementData[i].data, advertisementData[i].length);
-
-      this->_advDataLen += advertisementData[i].length;
-    }
-  }
-
-  if (scanDataSize && scanData) {
-    for (int i = 0; i < scanDataSize; i++) {
-      srData[srDataLen + 0] = scanData[i].length + 1;
-      srData[srDataLen + 1] = scanData[i].type;
-      srDataLen += 2;
-
-      memcpy(&srData[srDataLen], scanData[i].data, scanData[i].length);
-
-      srDataLen += scanData[i].length;
-    }
-  }
-
-  sd_ble_gap_adv_data_set(this->_advData, this->_advDataLen, srData, srDataLen);
+  sd_ble_gap_adv_data_set(this->_advData, this->_advDataLen, (uint8_t *)scanData, scanDataSize);
   sd_ble_gap_appearance_set(0);
 
   for (int i = 0; i < numLocalAttributes; i++) {

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -52,10 +52,10 @@ class nRF51822 : public BLEDevice
 
     virtual ~nRF51822();
 
-    virtual void begin(unsigned char advertisementDataSize,
-                BLEEirData *advertisementData,
+     virtual void begin(unsigned char advertisementDataSize,
+                unsigned char *advertisementData,
                 unsigned char scanDataSize,
-                BLEEirData *scanData,
+                unsigned char *scanData,
                 BLELocalAttribute** localAttributes,
                 unsigned char numLocalAttributes,
                 BLERemoteAttribute** remoteAttributes,


### PR DESCRIPTION
Hi Sandeep,
I added to the advertising module the capability to advertise more than a service, the appearance and the tx power. Take a look at the code and, if it can help you, add it to your repo. Here is a little example to try the new feature:

#include <BLEPeripheral.h>

BLEPeripheral blePeripheral    = BLEPeripheral();

BLEService    serviceOne       = BLEService("19b10001e8f2537e4f6cd104768a1214");
BLEService    serviceTwo       = BLEService("aaaa");
BLEService    serviceThree     = BLEService("bbbb");

void setup() {
  blePeripheral.setLocalName("AdvTest");
  blePeripheral.setAdvertisedServiceUuid(serviceOne.uuid());
  blePeripheral.setAdvertisedServiceUuid(serviceTwo.uuid());
  blePeripheral.setAdvertisedServiceUuid(serviceThree.uuid());
  blePeripheral.setAppearance(BLE_APPEARANCE_GENERIC_COMPUTER);
  blePeripheral.setTxPower(-40);
  blePeripheral.begin();
}

void loop() {}

Please notice that I tested this feature only with the nRF52 microcontroller.
Regards,
Chiara