### PR TITLE
Update API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -233,6 +233,12 @@ Choice of:
 or
 
   * value - string value (max: 20 characters on nRF8001 and nRF51822)
+  
+  Please take note that in order to initiate a characteristic containing one or more 0's (i.e. not a real string) you should use a combination of
+  ```
+  BLECharacteristic(const char* uuid, unsigned char properties, sizeof(value));
+  BLECharacteristic.setValue((unsigned char*)value, sizeof(value));
+  ```
 
 ## Get value
 ```c


### PR DESCRIPTION
Attempt at clarifying the BLECharacteristic initialisation when using non-string values containing 0's.