### PR TITLE
Make BLEDevice::requestTemperature() accessible for BLEPeripheral class.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@
   * broadcast [physical web](http://physical-web.org) beacon
 * [test](test)
   * read/write/notify characteristic for counter
+* [temp_sensor](temp_sensor)
+  * read temperature and humidity from adafruit DHT series sensors
+* [temp_soc](temp_sensor)
+  * request nRF SoC temperature and offer value on an service characteristic
 * [serial](serial)
   * serial port service compatible with following applications:
     - nRF Toolbox - [iOS](https://itunes.apple.com/us/app/nrf-toolbox/id820906058?mt=8) | [Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.nrftoolbox)

--- a/examples/temp_soc/temp_soc.ino
+++ b/examples/temp_soc/temp_soc.ino
@@ -1,0 +1,79 @@
+// Copyright (c) Bosch Software Innovations GmbH. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*
+ * Example sketch for requesting the nRF SoC temperature and 
+ * offer it via a temperature service charachteristic.
+ */
+
+#include <BLEPeripheral.h>
+
+class MyBle : public BLEPeripheral {
+public:
+  MyBle(unsigned char req, unsigned char rdy, unsigned char rst)
+      : BLEPeripheral(req, rdy, rst) {};
+  void init() {
+    addAttribute(srvTemp);
+    addAttribute(chrTemp);
+    addAttribute(dscTemp);
+    setDeviceName("Soc Temp");      // optional
+    setLocalName ("Soc Temp");      // max 20 char!
+    setAdvertisedServiceUuid(srvTemp.uuid()); // optional 
+  };
+private:
+  BLEService             srvTemp = BLEService            ("CCC0");
+  BLEFloatCharacteristic chrTemp = BLEFloatCharacteristic("CCC1", BLERead | BLENotify);
+  BLEDescriptor          dscTemp = BLEDescriptor         ("2901", "Temp. Celsius");
+  // overload callback:
+  void   BLEDeviceTemperatureReceived(BLEDevice& device, float temp) {
+    if (chrTemp.value()!=temp) {
+        chrTemp.setValue(temp);
+        Serial.print("Temp.[C]: "); Serial.println(temp);
+    }  
+  };
+};
+
+// for extern nRF8001 on shield/board
+// enable SPI & define pins 
+//#include <SPI.h>
+//#define BLE_REQ   10
+//#define BLE_RDY   2
+//#define BLE_RST   9
+
+// for nrf51 or nRF52 variants:
+#define BLE_REQ   0
+#define BLE_RDY   0
+#define BLE_RST   0
+
+// create ble temperature instance, see pinouts above
+MyBle    ble(BLE_REQ, BLE_RDY, BLE_RST);
+uint32_t timeStamp;
+
+void handleBleConnect(BLECentral& central) {
+  Serial.print("Connected event,    central: ");
+  Serial.println(central.address());
+}
+void handleBleDisconnect(BLECentral& central) {
+  Serial.print("Disconnected event, central: ");
+  Serial.println(central.address());
+}
+
+void setup() {
+  Serial.begin(115200);
+  ble.init();
+  ble.setEventHandler(BLEConnected,    handleBleConnect);
+  ble.setEventHandler(BLEDisconnected, handleBleDisconnect);
+  ble.begin();
+  ble.requestTemperature();
+  timeStamp = millis();
+  Serial.println("... nRF BLE setup done!");
+}
+
+void loop() {
+  ble.poll();
+  if ((millis()-timeStamp)> 1000) { //msec
+    timeStamp = millis();
+    ble.requestTemperature();
+  }
+}
+

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -202,6 +202,9 @@ bool  BLEPeripheral::setTxPower(int txPower) {
 void BLEPeripheral::setBondStore(BLEBondStore& bondStore) {
   this->_device->setBondStore(bondStore);
 }
+void BLEPeripheral::requestTemperature() {
+  this->_device->requestTemperature();
+}
 
 void BLEPeripheral::setDeviceName(const char* deviceName) {
   this->_deviceNameCharacteristic.setValue(deviceName);

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -74,6 +74,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     bool setTxPower(int txPower);
     void setConnectable(bool connectable);
     void setBondStore(BLEBondStore& bondStore);
+    void requestTemperature();
 
 
     void setDeviceName(const char* deviceName);


### PR DESCRIPTION
Signed-off-by: Joerg Hubschneider <joerg.hubschneider@bosch-si.com>
... reflecting issue #33 