### PR TITLE
allow calling poll() with BLE event data

### DIFF
--- a/src/BLECentral.cpp
+++ b/src/BLECentral.cpp
@@ -46,6 +46,10 @@ void BLECentral::poll() {
   this->_peripheral->poll();
 }
 
+void BLECentral::poll(void* eventData, uint16_t length) {
+  this->_peripheral->poll(eventData, length);
+}
+
 void BLECentral::disconnect() {
   if (this->connected()) {
     this->_peripheral->disconnect();

--- a/src/BLECentral.h
+++ b/src/BLECentral.h
@@ -18,6 +18,7 @@ class BLECentral
     bool connected();
     const char* address() const;
     void poll();
+    void poll(void* eventData, uint16_t length);
 
     void disconnect();
 

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -66,6 +66,7 @@ class BLEDevice
                 unsigned char /*numRemoteAttributes*/) { }
 
     virtual void poll() { }
+    virtual void poll(void* eventData, uint16_t length) { }
 
     virtual void end() { }
 

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -170,6 +170,10 @@ void BLEPeripheral::poll() {
   this->_device->poll();
 }
 
+void BLEPeripheral::poll(void* eventData, uint16_t length) {
+  this->_device->poll(eventData, length);
+}
+
 void BLEPeripheral::end() {
   this->_device->end();
 }
@@ -247,6 +251,12 @@ void BLEPeripheral::disconnect() {
 
 BLECentral BLEPeripheral::central() {
   this->poll();
+
+  return this->_central;
+}
+
+BLECentral BLEPeripheral::central(void* eventData, uint16_t length) {
+  this->poll(eventData, length);
 
   return this->_central;
 }

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -60,6 +60,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
     void begin();
     void poll();
+    void poll(void* eventData, uint16_t length);
     void end();
 
     void setAdvertisedServiceUuid(const char* advertisedServiceUuid);
@@ -86,6 +87,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     void disconnect();
 
     BLECentral central();
+    BLECentral central(void* eventData, uint16_t length);
     bool connected();
 
     void setEventHandler(BLEPeripheralEvent event, BLEPeripheralEventHandler eventHandler);

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -62,6 +62,7 @@ class nRF51822 : public BLEDevice
                 unsigned char numRemoteAttributes);
 
     virtual void poll();
+    virtual void poll(void* eventData, uint16_t length);
 
     virtual void end();
 

--- a/src/nRF8001.h
+++ b/src/nRF8001.h
@@ -56,6 +56,7 @@ class nRF8001 : protected BLEDevice
                 unsigned char numRemoteAttributes);
 
     virtual void poll();
+    virtual void poll(void* eventData, uint16_t length) { /* TODO */ };
 
     virtual void end();
 


### PR DESCRIPTION
Hi again Sandeep!

First of all, thank you again for your enormous contribution to the BLE community. I use your projects on a daily basis, and find them very valuable.

This pull request lets the user of the library pass the BLE event data to `poll()`, instead of have `poll()` get it directly from the BLE stack. 

My use case for this is - I have an app that acts as a BLE peripheral, while at the same time scans for BLE advertisements from nearby devices. That's the reason why I need to get the raw SoftDevice events. 

This is a sketch of how my code uses the proposed feature:

```
  uint32_t   evtBuf[(sizeof(ble_evt_t) + (GATT_MTU_SIZE_DEFAULT))];
  uint16_t   evtLen = sizeof(evtBuf);

  if (sd_ble_evt_get((uint8_t*)evtBuf, &evtLen) == NRF_SUCCESS) {
    ble_evt_t* bleEvt = (ble_evt_t*)evtBuf;
    // here I check if this is an BLE advertisement packet and handle it
  } else { 
    return;
  }

  BLECentral central = blePeripheral.central(evtBuf, evtLen);
  // do the usual stuff with the central object
```

So far, I have only implemented it for the NRF51 variant, as I wanted to get your feedback first, get your feedback about this approach, and see if it is heading the right direction. I would love to have some solution for my use case, and I am open for feedback on this PR before I continue working on this.

Thanks!