### PR TITLE
clarify BLEPeripheral constructor pin required, but hardcoded/ignored…

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,8 @@
 # BLEPeripheral
 
 ## Constructor
+Creates the BLEPeripheral object. Pin Arguments are optional as pins are self detecting. See https://github.com/sandeepmistry/arduino-BLEPeripheral#pinouts
+
 ```c
 BLEPeripheral(unsigned char req = BLE_DEFAULT_REQ, unsigned char rdy = BLE_DEFAULT_RDY, unsigned char rst = BLE_DEFAULT_RST);
  * req - REQ pin

--- a/API.md
+++ b/API.md
@@ -1,10 +1,8 @@
 # BLEPeripheral
 
 ## Constructor
-These pins are required by constrcutor, but are hard coded or ignored for some boards like those in the nrf5x core
 ```c
-BLEPeripheral(unsigned char req, unsigned char rdy, unsigned char rst);
-```
+BLEPeripheral(unsigned char req = BLE_DEFAULT_REQ, unsigned char rdy = BLE_DEFAULT_RDY, unsigned char rst = BLE_DEFAULT_RST);
  * req - REQ pin
  * rdy - RDY pin
  * rst - RST pin, can be ```UNUSED```

--- a/API.md
+++ b/API.md
@@ -1,6 +1,7 @@
 # BLEPeripheral
 
 ## Constructor
+These pins are required by constrcutor, but are hard coded or ignored for some boards like those in the nrf5x core
 ```c
 BLEPeripheral(unsigned char req, unsigned char rdy, unsigned char rst);
 ```

--- a/examples/Eddystone/EddystoneUID/EddystoneUID.ino
+++ b/examples/Eddystone/EddystoneUID/EddystoneUID.ino
@@ -5,18 +5,8 @@
 #include <SPI.h>
 #include <EddystoneBeacon.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-//
-//   Adafruit Bluefruit LE   10, 2, 9
-//   Blend                    9, 8, UNUSED
-//   Blend Micro              6, 7, 4
-//   RBL BLE Shield           9, 8, UNUSED
-
-#define EDDYSTONE_BEACON_REQ   6
-#define EDDYSTONE_BEACON_RDY   7
-#define EDDYSTONE_BEACON_RST   4
-
-EddystoneBeacon eddystoneBeacon = EddystoneBeacon(EDDYSTONE_BEACON_REQ, EDDYSTONE_BEACON_RDY, EDDYSTONE_BEACON_RST);
+//custom boards may override default pin definitions with EddystoneBeacon(PIN_REQ, PIN_RDY, PIN_RST)
+EddystoneBeacon eddystoneBeacon = EddystoneBeacon();
 BLEUuid         uid             = BLEUuid("01020304050607080910-AABBCCDDEEFF"); // <namespace id>-<instance id>
 
 void setup() {

--- a/examples/Eddystone/EddystoneUID/EddystoneUID.ino
+++ b/examples/Eddystone/EddystoneUID/EddystoneUID.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <EddystoneBeacon.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 //
 //   Adafruit Bluefruit LE   10, 2, 9
 //   Blend                    9, 8, UNUSED

--- a/examples/Eddystone/EddystoneURL/EddystoneURL.ino
+++ b/examples/Eddystone/EddystoneURL/EddystoneURL.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <EddystoneBeacon.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 //
 //   Adafruit Bluefruit LE   10, 2, 9
 //   Blend                    9, 8, UNUSED

--- a/examples/Eddystone/EddystoneURL/EddystoneURL.ino
+++ b/examples/Eddystone/EddystoneURL/EddystoneURL.ino
@@ -5,18 +5,8 @@
 #include <SPI.h>
 #include <EddystoneBeacon.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-//
-//   Adafruit Bluefruit LE   10, 2, 9
-//   Blend                    9, 8, UNUSED
-//   Blend Micro              6, 7, 4
-//   RBL BLE Shield           9, 8, UNUSED
-
-#define EDDYSTONE_BEACON_REQ   6
-#define EDDYSTONE_BEACON_RDY   7
-#define EDDYSTONE_BEACON_RST   4
-
-EddystoneBeacon eddystoneBeacon = EddystoneBeacon(EDDYSTONE_BEACON_REQ, EDDYSTONE_BEACON_RDY, EDDYSTONE_BEACON_RST);
+//custom boards may override default pin definitions with EddystoneBeacon(PIN_REQ, PIN_RDY, PIN_RST)
+EddystoneBeacon eddystoneBeacon = EddystoneBeacon();
 
 void setup() {
   Serial.begin(9600);

--- a/examples/HID/HID_joystick_mouse/HID_joystick_mouse.ino
+++ b/examples/HID/HID_joystick_mouse/HID_joystick_mouse.ino
@@ -11,13 +11,8 @@
 #define JOYSTICK_Y_AXIS_PIN A1
 #define JOYSTICK_RANGE 24
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   9
-#define BLE_RDY   8
-#define BLE_RST   4
-
-// create peripheral instance, see pinouts above
-BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEHIDPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral();
 BLEMouse bleMouse;
 
 int buttonState;

--- a/examples/HID/HID_joystick_mouse/HID_joystick_mouse.ino
+++ b/examples/HID/HID_joystick_mouse/HID_joystick_mouse.ino
@@ -11,7 +11,7 @@
 #define JOYSTICK_Y_AXIS_PIN A1
 #define JOYSTICK_RANGE 24
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   9
 #define BLE_RDY   8
 #define BLE_RST   4

--- a/examples/HID/HID_keyboard/HID_keyboard.ino
+++ b/examples/HID/HID_keyboard/HID_keyboard.ino
@@ -6,7 +6,7 @@
 #include <BLEHIDPeripheral.h>
 #include <BLEKeyboard.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   6
 #define BLE_RDY   7
 #define BLE_RST   4

--- a/examples/HID/HID_keyboard/HID_keyboard.ino
+++ b/examples/HID/HID_keyboard/HID_keyboard.ino
@@ -6,15 +6,10 @@
 #include <BLEHIDPeripheral.h>
 #include <BLEKeyboard.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   6
-#define BLE_RDY   7
-#define BLE_RST   4
-
 //#define ANDROID_CENTRAL
 
-// create peripheral instance, see pinouts above
-BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEHIDPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral();
 BLEKeyboard bleKeyboard;
 
 void setup() {

--- a/examples/HID/HID_keypad/HID_keypad.ino
+++ b/examples/HID/HID_keypad/HID_keypad.ino
@@ -22,7 +22,7 @@ byte colPins[COLS] = { 7, 6, 5 }; //connect to the column pinouts of the keypad
 
 Keypad keypad = Keypad( makeKeymap(keys), rowPins, colPins, ROWS, COLS );
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   9
 #define BLE_RDY   8
 #define BLE_RST   4

--- a/examples/HID/HID_keypad/HID_keypad.ino
+++ b/examples/HID/HID_keypad/HID_keypad.ino
@@ -22,13 +22,8 @@ byte colPins[COLS] = { 7, 6, 5 }; //connect to the column pinouts of the keypad
 
 Keypad keypad = Keypad( makeKeymap(keys), rowPins, colPins, ROWS, COLS );
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   9
-#define BLE_RDY   8
-#define BLE_RST   4
-
-// create peripheral instance, see pinouts above
-BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEHIDPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral();
 BLEKeyboard bleKeyboard;
 
 void setup() {

--- a/examples/HID/HID_test/HID_test.ino
+++ b/examples/HID/HID_test/HID_test.ino
@@ -9,7 +9,7 @@
 #include <BLEMultimedia.h>
 #include <BLESystemControl.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   6
 #define BLE_RDY   7
 #define BLE_RST   4

--- a/examples/HID/HID_test/HID_test.ino
+++ b/examples/HID/HID_test/HID_test.ino
@@ -9,12 +9,8 @@
 #include <BLEMultimedia.h>
 #include <BLESystemControl.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   6
-#define BLE_RDY   7
-#define BLE_RST   4
-
-BLEHIDPeripheral bleHID = BLEHIDPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEHIDPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEHIDPeripheral bleHID = BLEHIDPeripheral();
 BLEMouse bleMouse;
 BLEKeyboard bleKeyboard;
 BLEMultimedia bleMultimedia;

--- a/examples/HID/HID_volume/HID_volume.ino
+++ b/examples/HID/HID_volume/HID_volume.ino
@@ -9,11 +9,6 @@
 // http://www.pjrc.com/teensy/td_libs_Encoder.html
 #include <Encoder.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
 #define BUTTON_PIN 5
 
 #define ENC_RIGHT_PIN 3
@@ -23,7 +18,8 @@
 
 //#define ANDROID_CENTRAL
 
-BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEHIDPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEHIDPeripheral bleHIDPeripheral = BLEHIDPeripheral();
 BLEMultimedia bleMultimedia;
 
 Encoder encoder(ENC_RIGHT_PIN, ENC_LEFT_PIN);

--- a/examples/HID/HID_volume/HID_volume.ino
+++ b/examples/HID/HID_volume/HID_volume.ino
@@ -9,7 +9,7 @@
 // http://www.pjrc.com/teensy/td_libs_Encoder.html
 #include <Encoder.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/examples/ancs/ancs.ino
+++ b/examples/ancs/ancs.ino
@@ -7,7 +7,7 @@
 
 #include <BLEUtil.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   6
 #define BLE_RDY   7
 #define BLE_RST   4

--- a/examples/ancs/ancs.ino
+++ b/examples/ancs/ancs.ino
@@ -7,13 +7,8 @@
 
 #include <BLEUtil.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   6
-#define BLE_RDY   7
-#define BLE_RST   4
-
-// create peripheral instance, see pinouts above
-BLEPeripheral                    blePeripheral                            = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 BLEBondStore                     bleBondStore;
 
 // remote services

--- a/examples/ir_bridge/ir_bridge.ino
+++ b/examples/ir_bridge/ir_bridge.ino
@@ -8,7 +8,7 @@
 // https://github.com/shirriff/Arduino-IRremote
 #include <IRremote.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ     10
 #define BLE_RDY     2
 #define BLE_RST     9

--- a/examples/ir_bridge/ir_bridge.ino
+++ b/examples/ir_bridge/ir_bridge.ino
@@ -8,11 +8,6 @@
 // https://github.com/shirriff/Arduino-IRremote
 #include <IRremote.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ     10
-#define BLE_RDY     2
-#define BLE_RST     9
-
 #define IR_SEND_PIN 3
 #define IR_RECV_PIN 4
 
@@ -30,8 +25,8 @@ IRsend                           irSend                      = IRsend(/*IR_SEND_
 IRrecv                           irRecv                      = IRrecv(IR_RECV_PIN);
 IRValue                          irValue;
 
-// create peripheral instance, see pinouts above
-BLEPeripheral                    blePeripheral               = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create service and characteristics
 BLEService                       irService                   = BLEService("00004952-0000-bbbb-0123-456789abcdef");

--- a/examples/led/led.ino
+++ b/examples/led/led.ino
@@ -5,16 +5,11 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
 // LED pin
 #define LED_PIN   3
 
-// create peripheral instance, see pinouts above
-BLEPeripheral            blePeripheral        = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create service
 BLEService               ledService           = BLEService("19b10000e8f2537e4f6cd104768a1214");

--- a/examples/led/led.ino
+++ b/examples/led/led.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/examples/led_callback/led_callback.ino
+++ b/examples/led_callback/led_callback.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/examples/led_callback/led_callback.ino
+++ b/examples/led_callback/led_callback.ino
@@ -5,16 +5,11 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
 // LED pin
 #define LED_PIN   3
 
-// create peripheral instance, see pinouts above
-BLEPeripheral           blePeripheral        = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create service
 BLEService              ledService           = BLEService("19b10000e8f2537e4f6cd104768a1214");

--- a/examples/led_switch/led_switch.ino
+++ b/examples/led_switch/led_switch.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ     10
 #define BLE_RDY     2
 #define BLE_RST     9

--- a/examples/led_switch/led_switch.ino
+++ b/examples/led_switch/led_switch.ino
@@ -5,17 +5,12 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ     10
-#define BLE_RDY     2
-#define BLE_RST     9
-
 // LED and button pin
 #define LED_PIN     3
 #define BUTTON_PIN  4
 
-// create peripheral instance, see pinouts above
-BLEPeripheral            blePeripheral        = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create service
 BLEService               ledService           = BLEService("19b10010e8f2537e4f6cd104768a1214");

--- a/examples/remote_service/remote_service.ino
+++ b/examples/remote_service/remote_service.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   6
 #define BLE_RDY   7
 #define BLE_RST   4

--- a/examples/remote_service/remote_service.ino
+++ b/examples/remote_service/remote_service.ino
@@ -5,13 +5,8 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   6
-#define BLE_RDY   7
-#define BLE_RST   4
-
-// create peripheral instance, see pinouts above
-BLEPeripheral                    blePeripheral                            = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create remote services
 BLERemoteService                 remoteGenericAttributeService            = BLERemoteService("1800");

--- a/examples/remote_test/remote_test.ino
+++ b/examples/remote_test/remote_test.ino
@@ -6,13 +6,8 @@
 #include <BLEPeripheral.h>
 #include <BLEUtil.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   6
-#define BLE_RDY   7
-#define BLE_RST   4
-
-// create peripheral instance, see pinouts above
-BLEPeripheral                    blePeripheral                            = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create remote services
 BLERemoteService                 remoteService                            = BLERemoteService("fffffffffffffffffffffffffffffff0");

--- a/examples/remote_test/remote_test.ino
+++ b/examples/remote_test/remote_test.ino
@@ -6,7 +6,7 @@
 #include <BLEPeripheral.h>
 #include <BLEUtil.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   6
 #define BLE_RDY   7
 #define BLE_RST   4

--- a/examples/serial/BLESerial.h
+++ b/examples/serial/BLESerial.h
@@ -7,7 +7,7 @@
 class BLESerial : public BLEPeripheral, public Stream
 {
   public:
-    BLESerial(unsigned char req, unsigned char rdy, unsigned char rst);
+    BLESerial(unsigned char req = BLE_DEFAULT_REQ, unsigned char rdy = BLE_DEFAULT_RDY, unsigned char rst = BLE_DEFAULT_RST);
 
     void begin(...);
     void poll();

--- a/examples/serial/serial.ino
+++ b/examples/serial/serial.ino
@@ -20,13 +20,8 @@
 #include <BLEPeripheral.h>
 #include "BLESerial.h"
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
-// create ble serial instance, see pinouts above
-BLESerial BLESerial(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLESerial(PIN_REQ, PIN_RDY, PIN_RST)
+BLESerial BLESerial();
 
 
 void setup() {

--- a/examples/serial/serial.ino
+++ b/examples/serial/serial.ino
@@ -20,7 +20,7 @@
 #include <BLEPeripheral.h>
 #include "BLESerial.h"
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/examples/starter/starter.ino
+++ b/examples/starter/starter.ino
@@ -5,13 +5,8 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
-// create peripheral instance, see pinouts above
-BLEPeripheral blePeripheral = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // uuid's can be:
 //   16-bit: "ffff"

--- a/examples/starter/starter.ino
+++ b/examples/starter/starter.ino
@@ -5,7 +5,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/examples/temp_sensor/temp_sensor.ino
+++ b/examples/temp_sensor/temp_sensor.ino
@@ -8,17 +8,13 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
 #define DHTTYPE DHT22
 #define DHTPIN 3
 
 DHT dht(DHTPIN, DHTTYPE);
 
-BLEPeripheral blePeripheral = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 BLEService tempService = BLEService("CCC0");
 BLEFloatCharacteristic tempCharacteristic = BLEFloatCharacteristic("CCC1", BLERead | BLENotify);

--- a/examples/temp_sensor/temp_sensor.ino
+++ b/examples/temp_sensor/temp_sensor.ino
@@ -8,7 +8,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/examples/test/test.ino
+++ b/examples/test/test.ino
@@ -11,13 +11,8 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
-#define BLE_REQ   10
-#define BLE_RDY   2
-#define BLE_RST   9
-
-// create peripheral instance, see pinouts above
-BLEPeripheral                    blePeripheral       = BLEPeripheral(BLE_REQ, BLE_RDY, BLE_RST);
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
 
 // create service
 BLEService                       testService         = BLEService("fff0");

--- a/examples/test/test.ino
+++ b/examples/test/test.ino
@@ -11,7 +11,7 @@
 #include <SPI.h>
 #include <BLEPeripheral.h>
 
-// define pins (varies per shield/board)
+// define pins (varies per shield/board), required, but are hard coded or ignored for some boards like those in the nrf5x core
 #define BLE_REQ   10
 #define BLE_RDY   2
 #define BLE_RST   9

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -34,11 +34,16 @@
   #define BLE_DEFAULT_REQ   6
   #define BLE_DEFAULT_RDY   7
   #define BLE_DEFAULT_RST   4
+#elif defined(BLEND)
+  #define BLE_DEFAULT_REQ   9
+  #define BLE_DEFAULT_RDY   8
+  #define BLE_DEFAULT_RST   4
 #else
   #define BLE_DEFAULT_REQ   10
   #define BLE_DEFAULT_RDY   2
   #define BLE_DEFAULT_RST   9
 #endif
+
 
 enum BLEPeripheralEvent {
   BLEConnected = 0,


### PR DESCRIPTION
… for some boards

Happy to argue verbiage