### PR TITLE
[RFC] add a bunch of hackish (but working) observer role functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,33 +3,11 @@
 [![Build Status](https://travis-ci.org/sandeepmistry/arduino-BLEPeripheral.svg?branch=master)](https://travis-ci.org/sandeepmistry/arduino-BLEPeripheral) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sandeepmistry/arduino-BLEPeripheral?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
-An [Arduino](http://arduino.cc) library for creating custom BLE peripherals with [Nordic Semiconductor](http://www.nordicsemi.com)'s [nRF8001](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF8001) or [nR51822](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822).
+An [Arduino](http://arduino.cc) library for creating custom BLE peripherals and observers with [Nordic Semiconductor](http://www.nordicsemi.com)'s  [nR51822](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822).
 
-Enables you to create more customized BLE Peripheral's compared to the basic UART most other Arduino BLE libraries provide.
-
-[nRFgo Studio](http://www.nordicsemi.com/chi/node_176/2.4GHz-RF/nRFgo-Studio) (and Windows) is not required when using the [nRF8001](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF8001).
+This is heavily based on @sandeepmistry's [arduino-BLEPeripheral](https://github.com/sandeepmistry/arduino-BLEPeripheral) library. This fork adds support for the observer role (i.e. receiving Bluetooth advertisements), but consequently can't support the nRF8001 anymore.
 
 ## Compatible Hardware
-
-### [Nordic Semiconductor nRF8001](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF8001)
-
- * [Adafruit](http://www.adafruit.com)
-   * [Bluefruit LE - nRF8001 Breakout](http://www.adafruit.com/products/1697)
- * [RedBearLab](http://redbearlab.com)
-   * [BLE Shield](http://redbearlab.com/bleshield/)
-   * [Blend Micro](http://redbearlab.com/blendmicro/)
-   * [Blend](http://redbearlab.com/blend/)
- * [Femtoduino](http://www.femtoduino.com)
-   * [IMUduino BTLE](http://www.femtoduino.com/spex/imuduino-btle)
- * [Olimex](https://www.olimex.com)
-   * [MOD-nRF8001](https://www.olimex.com/Products/Modules/RF/MOD-nRF8001/)
-   * [OLIMEXINO-NANO-BLE](https://www.olimex.com/Products/Duino/AVR/OLIMEXINO-NANO-BLE/)
- * [Jaycon Systems](http://www.jayconsystems.com)
-   * [nRF8001 Bluetooth Breakout Board](http://www.jayconsystems.com/nrf8001-breakout-board.html)
- * [TinyCircuits](https://www.tiny-circuits.com)
-  * [TinyShield Bluetooth Low Energy - Nordic](https://www.tiny-circuits.com/tiny-shield-bluetooth-low-energy-nordic.html)
-
-**Note:** Does not require use of [nRFgo Studio](http://www.nordicsemi.com/chi/node_176/2.4GHz-RF/nRFgo-Studio)! However, uses more code space.
 
 ### [Nordic Semiconductor nRF51822](http://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822)
 
@@ -44,39 +22,6 @@ Enables you to create more customized BLE Peripheral's compared to the basic UAR
 
  * Various, see [arduino-nRF5 supported boards](https://github.com/sandeepmistry/arduino-nRF5#supported-boards) via [nRF5 Arduino Add-on](https://github.com/sandeepmistry/arduino-nRF5)
 
-#### Pinouts
-
-| Chip | Shield/Board | REQ Pin | RDY Pin | RST Pin |
-| ---- | ------------ | ------- | ------- | ------- |
-| nRF8001|
-| | Bluefruit LE | 10 | 2 | 9 |
-| | BLE Shield 1.x | 9 | 8 | UNUSED |
-| | BLE Shield 2.x | 9 | 8 | UNUSED or 4/7 via jumper|
-| | Blend | 9 | 8 | UNUSED or 4/5 via jumper |
-| | Blend Micro | 6 | 7 | UNUSED or 4 |
-| | IMUduino BTLE | 10 | 7 | 9 |
-| | TinyShield Bluetooth Low Energy | 10 | 2 | 9 |
-| nRF51822 |
-| | RedBearLab nRF51822 | -1 (UNUSED) | -1 (UNUSED) | -1 (UNUSED) |
-| | BLE Nano | -1 (UNUSED) | -1 (UNUSED) | -1 (UNUSED) |
-| | RFduino | -1 (UNUSED) | -1 (UNUSED) | -1 (UNUSED) |
-
-## Compatible IDE's and MCU's
-
- * [Arduino IDE](http://arduino.cc/en/Main/Software#toc1)
-   * AVR (Uno, Lenoardo, Mega, etc.)
-   * SAM3X8E (Due)
-   * SAMD21G18A (Zero)
- * [Teensy](https://www.pjrc.com/teensy/) (via [Teensyduino](https://www.pjrc.com/teensy/td_download.html))
-   * 2.0
-   * 3.0
-   * 3.1
-   * LC
-
-**Warning**: For more advanced sketches an MCU with more than 2kB of RAM and 32kB of flash space is recommended. Advance sketches include:
- * Multiple services and characteristics
- * HID API usage
-
 ## Usage
 
 ### Download Library
@@ -86,20 +31,20 @@ Enables you to create more customized BLE Peripheral's compared to the basic UAR
 #### Using the Arduino IDE Library Manager
 
 1. Choose ```Sketch``` -> ```Include Library``` -> ```Manage Libraries...```
-2. Type ```BLEPeripheral``` into the search box.
+2. Type ```BLEPeripheralObserver``` into the search box.
 3. Click the row to select the library.
 4. Click the ```Install``` button to install the library.
 
 #### Using Git
 ```sh
 cd ~/Documents/Arduino/libraries/
-git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
+git clone https://github.com/floe/BLEPeripheralObserver BLEPeripheralObserver
 ```
 
 #### MPIDE
 ```
 cd ~/Documents/mpide/libraries/
-git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
+git clone https://github.com/floe/BLEPeripheralObserver BLEPeripheralObserver
 ```
 
 ### [arduino-nRF5x core](https://github.com/sandeepmistry/arduino-nRF5) users
@@ -120,15 +65,3 @@ See [examples](examples) folder.
 ## License
 
 This libary is [licensed](LICENSE) under the [MIT Licence](http://en.wikipedia.org/wiki/MIT_License).
-
-## Useful Links
- * [@lizardo](https://github.com/lizardo)'s [nRF8001 Experiments](https://github.com/lizardo/nrf8001)
-   * used as a starting point to reverse engineer the proprietary setup message format for the chips
- * [@NordicSemiconductor](https://github.com/NordicSemiconductor)'s [ble-sdk-arduino](https://github.com/NordicSemiconductor/ble-sdk-arduino)
-   * Original Arduino SDK for nRF8001
- * [@guanix](https://github.com/guanix)'s [arduino-nrf8001](https://github.com/guanix/arduino-nrf8001)
-   * nRF8001 support for Arduino
-
-
-[![Analytics](https://ga-beacon.appspot.com/UA-56089547-1/sandeepmistry/arduino-BLEPeripheral?pixel)](https://github.com/igrigorik/ga-beacon)
-

--- a/examples/observer/observer.ino
+++ b/examples/observer/observer.ino
@@ -1,0 +1,50 @@
+// Copyright (c) Sandeep Mistry. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#define NRF51
+#undef __RFduino__
+// Import libraries (BLEPeripheral depends on SPI)
+#include <SPI.h>
+#include <BLEPeripheral.h>
+#include <BLEUtil.h>
+#include <ble_gap.h>
+
+//custom boards may override default pin definitions with BLEPeripheral(PIN_REQ, PIN_RDY, PIN_RST)
+BLEPeripheral                    blePeripheral                            = BLEPeripheral();
+
+void setup() {
+  Serial.begin(115200);
+#if defined (__AVR_ATmega32U4__)
+  delay(5000);  //5 seconds delay for enabling to see the start up comments on the serial board
+#endif
+
+  blePeripheral.setLocalName("foobaz"); // optional
+  
+  // begin initialization
+  blePeripheral.begin();
+  blePeripheral.setConnectable(false);
+  blePeripheral.setAdvertisingInterval(500);
+  blePeripheral.startAdvertising();
+  blePeripheral.setEventHandler(BLEAdvertisementReceived, advHandler);
+}
+
+void advHandler(const void* adv) {
+  ble_gap_evt_adv_report_t* report = (ble_gap_evt_adv_report_t*)adv;
+  char address[18];
+  BLEUtil::addressToString(report->peer_addr.addr, address);
+  Serial.print(F("Evt Adv Report from "));
+  Serial.println(address);
+  Serial.print(F("got adv with payload "));
+  Serial.println(report->dlen);
+}
+
+void loop() {
+  if (Serial.available() > 0) {
+    Serial.read();
+    Serial.println("start scanning");
+    blePeripheral.startScanning();
+    blePeripheral.setLocalName("foobarg"); // optional
+    blePeripheral.startAdvertising();
+  }
+  blePeripheral.poll();
+}

--- a/examples/observer/observer.ino
+++ b/examples/observer/observer.ino
@@ -20,12 +20,22 @@ void setup() {
 
   blePeripheral.setLocalName("foobaz"); // optional
   
+  blePeripheral.setEventHandler(BLEAddressReceived, addrHandler);
+  blePeripheral.setEventHandler(BLEAdvertisementReceived, advHandler);
+
   // begin initialization
   blePeripheral.begin();
   blePeripheral.setConnectable(false);
   blePeripheral.setAdvertisingInterval(500);
   blePeripheral.startAdvertising();
-  blePeripheral.setEventHandler(BLEAdvertisementReceived, advHandler);
+}
+
+void addrHandler(const void* _addr) {
+  unsigned char* addr = (unsigned char*)_addr;
+  char address[18];
+  BLEUtil::addressToString(addr, address);
+  Serial.print(F("Got own addr: "));
+  Serial.println(address);
 }
 
 void advHandler(const void* adv) {

--- a/library.json
+++ b/library.json
@@ -1,13 +1,13 @@
 {
-  "name": "BLEPeripheral",
+  "name": "BLEPeripheralObserver",
   "version": "0.4.0",
-  "keywords": "BLE, bluetooth, peripheral",
-  "description": "Arduino library for creating custom BLE peripherals. Supports nRF8001 and nRF51822 based boards/shields.",
+  "keywords": "BLE, bluetooth, peripheral, observer",
+  "description": "Arduino library for creating custom BLE peripherals. Supports nRF51 based boards.",
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/sandeepmistry/arduino-BLEPeripheral.git"
+    "url": "https://github.com/floe/BLEPeripheralObserver.git"
   },
   "frameworks": "arduino",
-  "platforms": "nordicnrf51, atmelavr, atmelsam, teensy"
+  "platforms": "nordicnrf51"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
-name=BLEPeripheral
+name=BLEPeripheralObserver
 version=0.4.0
-author=Sandeep Mistry <sandeep.mistry@gmail.com>
-maintainer=Sandeep Mistry <sandeep.mistry@gmail.com>
-sentence=An Arduino library for creating custom BLE peripherals.
-paragraph=Supports nRF8001 and nRF51822 based boards/shields
+author=Sandeep Mistry <sandeep.mistry@gmail.com>, Florian Echtler <floe@butterbrot.org>
+maintainer=Florian Echtler <floe@butterbrot.org>
+sentence=An Arduino library for creating custom BLE peripherals and observers.
+paragraph=Supports nRF51 and nRF52 based boards
 category=Communication
-url=https://github.com/sandeepmistry/arduino-BLEPeripheral
+url=https://github.com/floe/BLEPeripheralObserver
 architectures=*
 includes=BLEPeripheral.h

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Supports nRF51 and nRF52 based boards
 category=Communication
 url=https://github.com/floe/BLEPeripheralObserver
 architectures=*
-includes=BLEPeripheral.h
+includes=BLEPeripheralObserver.h

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -65,6 +65,11 @@ class BLEDevice
                 BLERemoteAttribute** /*remoteAttributes*/,
                 unsigned char /*numRemoteAttributes*/) { }
 
+    virtual void updateAdvertisementData(unsigned char /*advertisementDataSize*/,
+                BLEEirData * /*advertisementData*/,
+                unsigned char /*scanDataSize*/,
+                BLEEirData * /*scanData*/) { }
+
     virtual void poll() { }
 
     virtual void end() { }

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -37,6 +37,7 @@ class BLEDeviceEventListener
     virtual void BLEDeviceAddressReceived(BLEDevice& /*device*/, const unsigned char* /*address*/) { }
     virtual void BLEDeviceTemperatureReceived(BLEDevice& /*device*/, float /*temperature*/) { }
     virtual void BLEDeviceBatteryLevelReceived(BLEDevice& /*device*/, float /*batteryLevel*/) { }
+    virtual void BLEDeviceAdvertisementReceived(BLEDevice& /*device*/, const unsigned char* /*advertisement*/) { }
 };
 
 

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -72,6 +72,9 @@ class BLEDevice
     virtual bool setTxPower(int /*txPower*/) { return false; }
 
     virtual void startAdvertising() { }
+    virtual void stopAdvertising() { }
+    virtual void startScanning() { }
+    virtual void stopScanning() { }
     virtual void disconnect() { }
 
     virtual bool updateCharacteristicValue(BLECharacteristic& /*characteristic*/) { return false; }

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -203,6 +203,22 @@ void BLEPeripheral::setBondStore(BLEBondStore& bondStore) {
   this->_device->setBondStore(bondStore);
 }
 
+void BLEPeripheral::startAdvertising() {
+  this->_device->startAdvertising();
+}
+
+void BLEPeripheral::stopAdvertising() {
+  this->_device->stopAdvertising();
+}
+
+void BLEPeripheral::startScanning() {
+  this->_device->startScanning();
+}
+
+void BLEPeripheral::stopScanning() {
+  this->_device->stopScanning();
+}
+
 void BLEPeripheral::setDeviceName(const char* deviceName) {
   this->_deviceNameCharacteristic.setValue(deviceName);
 }

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -405,7 +405,7 @@ void BLEPeripheral::BLEDeviceRemoteCharacteristicValueChanged(BLEDevice& /*devic
   remoteCharacteristic.setValue(this->_central, value, valueLength);
 }
 
-void BLEPeripheral::BLEDeviceAddressReceived(BLEDevice& /*device*/, const unsigned char* /*address*/) {
+void BLEPeripheral::BLEDeviceAddressReceived(BLEDevice& device, const unsigned char* address) {
 #ifdef BLE_PERIPHERAL_DEBUG
   char addressStr[18];
 
@@ -414,6 +414,10 @@ void BLEPeripheral::BLEDeviceAddressReceived(BLEDevice& /*device*/, const unsign
   Serial.print(F("Peripheral address: "));
   Serial.println(addressStr);
 #endif
+  BLEDeviceEventHandler eventHandler = this->_deviceEvents[BLEAddressReceived];
+  if (eventHandler) {
+    eventHandler(address);
+  }
 }
 
 void BLEPeripheral::BLEDeviceTemperatureReceived(BLEDevice& device, float temperature) {

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -49,6 +49,7 @@ BLEPeripheral::BLEPeripheral(unsigned char req, unsigned char rdy, unsigned char
 #endif
 
   memset(this->_eventHandlers, 0x00, sizeof(this->_eventHandlers));
+  memset(this->_deviceEvents,  0x00, sizeof(this->_deviceEvents));
 
   this->setDeviceName(DEFAULT_DEVICE_NAME);
   this->setAppearance(DEFAULT_APPEARANCE);
@@ -286,6 +287,12 @@ void BLEPeripheral::setEventHandler(BLEPeripheralEvent event, BLEPeripheralEvent
   }
 }
 
+void BLEPeripheral::setEventHandler(BLEDeviceEvent event, BLEDeviceEventHandler eventHandler) {
+  if (event < sizeof(this->_deviceEvents)) {
+    this->_deviceEvents[event] = eventHandler;
+  }
+}
+
 bool BLEPeripheral::characteristicValueChanged(BLECharacteristic& characteristic) {
   return this->_device->updateCharacteristicValue(characteristic);
 }
@@ -409,10 +416,25 @@ void BLEPeripheral::BLEDeviceAddressReceived(BLEDevice& /*device*/, const unsign
 #endif
 }
 
-void BLEPeripheral::BLEDeviceTemperatureReceived(BLEDevice& /*device*/, float /*temperature*/) {
+void BLEPeripheral::BLEDeviceTemperatureReceived(BLEDevice& device, float temperature) {
+  BLEDeviceEventHandler eventHandler = this->_deviceEvents[BLETemperatureReceived];
+  if (eventHandler) {
+    eventHandler(&temperature);
+  }
 }
 
-void BLEPeripheral::BLEDeviceBatteryLevelReceived(BLEDevice& /*device*/, float /*batteryLevel*/) {
+void BLEPeripheral::BLEDeviceBatteryLevelReceived(BLEDevice& device, float batteryLevel) {
+  BLEDeviceEventHandler eventHandler = this->_deviceEvents[BLEBatteryLevelReceived];
+  if (eventHandler) {
+    eventHandler(&batteryLevel);
+  }
+}
+
+void BLEPeripheral::BLEDeviceAdvertisementReceived(BLEDevice& device, const unsigned char* advertisement) {
+  BLEDeviceEventHandler eventHandler = this->_deviceEvents[BLEAdvertisementReceived];
+  if (eventHandler) {
+    eventHandler(advertisement);
+  }
 }
 
 void BLEPeripheral::initLocalAttributes() {

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -68,11 +68,8 @@ BLEPeripheral::~BLEPeripheral() {
   }
 }
 
-void BLEPeripheral::begin() {
+unsigned char BLEPeripheral::updateAdvertismentData() {
   unsigned char advertisementDataSize = 0;
-
-  BLEEirData advertisementData[3];
-  BLEEirData scanData;
 
   scanData.length = 0;
 
@@ -131,6 +128,11 @@ void BLEPeripheral::begin() {
     memcpy(scanData.data, this->_localName, scanData.length);
   }
 
+  return advertisementDataSize;
+}
+
+void BLEPeripheral::begin() {
+
   if (this->_localAttributes == NULL) {
     this->initLocalAttributes();
   }
@@ -158,6 +160,7 @@ void BLEPeripheral::begin() {
     this->addRemoteAttribute(this->_remoteServicesChangedCharacteristic);
   }
 
+  int advertisementDataSize = updateAdvertismentData();
   this->_device->begin(advertisementDataSize, advertisementData,
                         scanData.length > 0 ? 1 : 0, &scanData,
                         this->_localAttributes, this->_numLocalAttributes,

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -207,6 +207,10 @@ void BLEPeripheral::setBondStore(BLEBondStore& bondStore) {
 }
 
 void BLEPeripheral::startAdvertising() {
+  int advertisementDataSize = updateAdvertismentData();
+  this->_device->updateAdvertisementData(
+      advertisementDataSize, advertisementData,
+      scanData.length > 0 ? 1 : 0, &scanData);
   this->_device->startAdvertising();
 }
 

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -57,7 +57,8 @@ typedef void (*BLEPeripheralEventHandler)(BLECentral& central);
 enum BLEDeviceEvent {
   BLETemperatureReceived = 0,
   BLEBatteryLevelReceived = 1,
-  BLEAdvertisementReceived = 2
+  BLEAdvertisementReceived = 2,
+  BLEAddressReceived = 3
 };
 
 typedef void (*BLEDeviceEventHandler)(const void* parameter);

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -130,6 +130,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
   private:
     void initLocalAttributes();
+    unsigned char updateAdvertismentData();
 
   private:
     BLEDevice*                     _device;
@@ -162,6 +163,9 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
     BLECentral                     _central;
     BLEPeripheralEventHandler      _eventHandlers[4];
+
+    BLEEirData                     advertisementData[3];
+    BLEEirData                     scanData;
 };
 
 #endif

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -80,6 +80,10 @@ class BLEPeripheral : public BLEDeviceEventListener,
     void setConnectable(bool connectable);
     void setBondStore(BLEBondStore& bondStore);
 
+    void startAdvertising();
+    void stopAdvertising();
+    void startScanning();
+    void stopScanning();
 
     void setDeviceName(const char* deviceName);
     void setAppearance(unsigned short appearance);

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -54,6 +54,13 @@ enum BLEPeripheralEvent {
 
 typedef void (*BLEPeripheralEventHandler)(BLECentral& central);
 
+enum BLEDeviceEvent {
+  BLETemperatureReceived = 0,
+  BLEBatteryLevelReceived = 1,
+  BLEAdvertisementReceived = 2
+};
+
+typedef void (*BLEDeviceEventHandler)(const void* parameter);
 
 class BLEPeripheral : public BLEDeviceEventListener,
                         public BLECharacteristicValueChangeListener,
@@ -98,6 +105,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     bool connected();
 
     void setEventHandler(BLEPeripheralEvent event, BLEPeripheralEventHandler eventHandler);
+    void setEventHandler(BLEDeviceEvent event, BLEDeviceEventHandler eventHandler);
 
   protected:
     bool characteristicValueChanged(BLECharacteristic& characteristic);
@@ -127,6 +135,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     virtual void BLEDeviceAddressReceived(BLEDevice& device, const unsigned char* address);
     virtual void BLEDeviceTemperatureReceived(BLEDevice& device, float temperature);
     virtual void BLEDeviceBatteryLevelReceived(BLEDevice& device, float batteryLevel);
+    virtual void BLEDeviceAdvertisementReceived(BLEDevice& device, const unsigned char* advertisement);
 
   private:
     void initLocalAttributes();
@@ -163,6 +172,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
     BLECentral                     _central;
     BLEPeripheralEventHandler      _eventHandlers[4];
+    BLEDeviceEventHandler          _deviceEvents[3];
 
     BLEEirData                     advertisementData[3];
     BLEEirData                     scanData;

--- a/src/BLEPeripheralObserver.h
+++ b/src/BLEPeripheralObserver.h
@@ -1,0 +1,1 @@
+#include "BLEPeripheral.h"

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -519,6 +519,7 @@ void nRF51822::poll() {
 
   if (sd_ble_evt_get((uint8_t*)evtBuf, &evtLen) == NRF_SUCCESS) {
     switch (bleEvt->header.evt_id) {
+#ifndef __RFduino__
       case BLE_GAP_EVT_ADV_REPORT:
 //#ifdef NRF_51822_DEBUG
         char address[18];
@@ -528,6 +529,7 @@ void nRF51822::poll() {
 //#endif
         this->_scanResult = &(bleEvt->evt.gap_evt.params.adv_report);
         break;
+#endif
 
       case BLE_EVT_TX_COMPLETE:
 #ifdef NRF_51822_DEBUG
@@ -1364,6 +1366,7 @@ void nRF51822::startScanning() {
   Serial.println(F("Start scanning"));
 #endif
 
+#ifndef __RFduino__
   // see https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s130.api.v2.0.1%2Fstructble__gap__scan__params__t.html
   ble_gap_scan_params_t scanParameters;
 
@@ -1377,10 +1380,13 @@ void nRF51822::startScanning() {
   scanParameters.window      = 0xA0;  // 100 ms
 
   sd_ble_gap_scan_start(&scanParameters);
+#endif
 }
 
 void nRF51822::stopScanning() {
+#ifndef __RFduino__
   sd_ble_gap_scan_stop();
+#endif
 }
 
 void nRF51822::disconnect() {

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -505,7 +505,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
 #endif
   }
 
-  //this->startAdvertising();
+  this->startAdvertising();
 
 #ifdef __RFduino__
   RFduinoBLE_enabled = 1;

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -52,7 +52,6 @@ nRF51822::nRF51822() :
 
   _advDataLen(0),
   _hasScanData(false),
-  _scanResult(NULL),
   _broadcastCharacteristic(NULL),
 
   _connectionHandle(BLE_CONN_HANDLE_INVALID),
@@ -534,13 +533,15 @@ void nRF51822::poll() {
     switch (bleEvt->header.evt_id) {
 #ifndef __RFduino__
       case BLE_GAP_EVT_ADV_REPORT:
-//#ifdef NRF_51822_DEBUG
+#ifdef NRF_51822_DEBUG
         char address[18];
         BLEUtil::addressToString(bleEvt->evt.gap_evt.params.adv_report.peer_addr.addr, address);
-        Serial.print(F("Evt Adv Report "));
+        Serial.print(F("Evt Adv Report from "));
         Serial.println(address);
-//#endif
-        this->_scanResult = &(bleEvt->evt.gap_evt.params.adv_report);
+#endif
+        if (this->_eventListener) {
+          this->_eventListener->BLEDeviceAdvertisementReceived(*this, (const unsigned char*)&(bleEvt->evt.gap_evt.params.adv_report));
+        }
         break;
 #endif
 

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -48,6 +48,7 @@ nRF51822::nRF51822() :
 
   _advDataLen(0),
   _hasScanData(false),
+  _scanResult(NULL),
   _broadcastCharacteristic(NULL),
 
   _connectionHandle(BLE_CONN_HANDLE_INVALID),
@@ -520,10 +521,12 @@ void nRF51822::poll() {
     switch (bleEvt->header.evt_id) {
       case BLE_GAP_EVT_ADV_REPORT:
 //#ifdef NRF_51822_DEBUG
-        Serial.print(F("Evt Adv Report, dlen = "));
-        Serial.println(bleEvt->evt.gap_evt.params.adv_report.dlen);
+        char address[18];
+        BLEUtil::addressToString(bleEvt->evt.gap_evt.params.adv_report.peer_addr.addr, address);
+        Serial.print(F("Evt Adv Report "));
+        Serial.println(address);
 //#endif
-        //this->_scanResult = &(bleEvt->evt.gap_evt.params.adv_report);
+        this->_scanResult = &(bleEvt->evt.gap_evt.params.adv_report);
         break;
 
       case BLE_EVT_TX_COMPLETE:
@@ -1021,6 +1024,10 @@ void nRF51822::poll() {
   // sd_app_evt_wait();
 }
 
+/*uint8_t* nRF51822::getScanResult() {
+  return _scanResult->data;
+}*/
+
 void nRF51822::end() {
   sd_softdevice_disable();
 
@@ -1362,12 +1369,12 @@ void nRF51822::startScanning() {
 
   memset(&scanParameters, 0x00, sizeof(scanParameters));
 
-  scanParameters.active      = 1;    // send scan requests
-  scanParameters.interval    = 0x40; // 40 ms in units of 0.625 ms
-  scanParameters.p_whitelist = NULL; // no whitelist
+  scanParameters.active      = 1;     // send scan requests
+  scanParameters.interval    = 0x140; // 200 ms in units of 0.625 ms
+  scanParameters.p_whitelist = NULL;  // no whitelist
   scanParameters.selective   = 0;
-  scanParameters.timeout     = 10;   // 10 seconds timeout
-  scanParameters.window      = 0x20; // 20 ms
+  scanParameters.timeout     = 10;    // 10 seconds timeout
+  scanParameters.window      = 0xA0;  // 100 ms
 
   sd_ble_gap_scan_start(&scanParameters);
 }

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -47,6 +47,7 @@ nRF51822::nRF51822() :
   BLEDevice(),
 
   _advDataLen(0),
+  _hasScanData(false),
   _broadcastCharacteristic(NULL),
 
   _connectionHandle(BLE_CONN_HANDLE_INVALID),
@@ -215,6 +216,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
       memcpy(&srData[srDataLen], scanData[i].data, scanData[i].length);
 
       srDataLen += scanData[i].length;
+      _hasScanData = true;
     }
   }
 
@@ -1328,7 +1330,7 @@ void nRF51822::startAdvertising() {
 
   memset(&advertisingParameters, 0x00, sizeof(advertisingParameters));
 
-  advertisingParameters.type        = this->_connectable ? BLE_GAP_ADV_TYPE_ADV_IND : BLE_GAP_ADV_TYPE_ADV_NONCONN_IND;
+  advertisingParameters.type        = this->_connectable ? BLE_GAP_ADV_TYPE_ADV_IND : ( this->_hasScanData ? BLE_GAP_ADV_TYPE_ADV_SCAN_IND : BLE_GAP_ADV_TYPE_ADV_NONCONN_IND );
   advertisingParameters.p_peer_addr = NULL;
   advertisingParameters.fp          = BLE_GAP_ADV_FP_ANY;
   advertisingParameters.p_whitelist = NULL;

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -502,7 +502,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
 #endif
   }
 
-  this->startAdvertising();
+  //this->startAdvertising();
 
 #ifdef __RFduino__
   RFduinoBLE_enabled = 1;
@@ -516,6 +516,14 @@ void nRF51822::poll() {
 
   if (sd_ble_evt_get((uint8_t*)evtBuf, &evtLen) == NRF_SUCCESS) {
     switch (bleEvt->header.evt_id) {
+      case BLE_GAP_EVT_ADV_REPORT:
+//#ifdef NRF_51822_DEBUG
+        Serial.print(F("Evt Adv Report, dlen = "));
+        Serial.println(bleEvt->evt.gap_evt.params.adv_report.dlen);
+//#endif
+        //this->_scanResult = &(bleEvt->evt.gap_evt.params.adv_report);
+        break;
+
       case BLE_EVT_TX_COMPLETE:
 #ifdef NRF_51822_DEBUG
         Serial.print(F("Evt TX complete "));
@@ -1336,6 +1344,34 @@ void nRF51822::startAdvertising() {
   advertisingParameters.timeout     = 0;
 
   sd_ble_gap_adv_start(&advertisingParameters);
+}
+
+void nRF51822::stopAdvertising() {
+  sd_ble_gap_adv_stop();
+}
+
+void nRF51822::startScanning() {
+#ifdef NRF_51822_DEBUG
+  Serial.println(F("Start scanning"));
+#endif
+
+  // see https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.s130.api.v2.0.1%2Fstructble__gap__scan__params__t.html
+  ble_gap_scan_params_t scanParameters;
+
+  memset(&scanParameters, 0x00, sizeof(scanParameters));
+
+  scanParameters.active      = 1;    // send scan requests
+  scanParameters.interval    = 0x40; // 40 ms in units of 0.625 ms
+  scanParameters.p_whitelist = NULL; // no whitelist
+  scanParameters.selective   = 0;
+  scanParameters.timeout     = 10;   // 10 seconds timeout
+  scanParameters.window      = 0x20; // 20 ms
+
+  sd_ble_gap_scan_start(&scanParameters);
+}
+
+void nRF51822::stopScanning() {
+  sd_ble_gap_scan_stop();
 }
 
 void nRF51822::disconnect() {

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -82,6 +82,52 @@ nRF51822::~nRF51822() {
   this->end();
 }
 
+void nRF51822::updateAdvertisementData(unsigned char advertisementDataSize,
+                      BLEEirData *advertisementData,
+                      unsigned char scanDataSize,
+                      BLEEirData *scanData)
+{
+  unsigned char srData[31];
+  unsigned char srDataLen = 0;
+
+  this->_advDataLen = 0;
+
+  // flags
+  this->_advData[this->_advDataLen + 0] = 2;
+  this->_advData[this->_advDataLen + 1] = 0x01;
+  this->_advData[this->_advDataLen + 2] = 0x06;
+
+  this->_advDataLen += 3;
+
+  if (advertisementDataSize && advertisementData) {
+    for (int i = 0; i < advertisementDataSize; i++) {
+      this->_advData[this->_advDataLen + 0] = advertisementData[i].length + 1;
+      this->_advData[this->_advDataLen + 1] = advertisementData[i].type;
+      this->_advDataLen += 2;
+
+      memcpy(&this->_advData[this->_advDataLen], advertisementData[i].data, advertisementData[i].length);
+
+      this->_advDataLen += advertisementData[i].length;
+    }
+  }
+
+  if (scanDataSize && scanData) {
+    for (int i = 0; i < scanDataSize; i++) {
+      srData[srDataLen + 0] = scanData[i].length + 1;
+      srData[srDataLen + 1] = scanData[i].type;
+      srDataLen += 2;
+
+      memcpy(&srData[srDataLen], scanData[i].data, scanData[i].length);
+
+      srDataLen += scanData[i].length;
+      _hasScanData = true;
+    }
+  }
+
+  sd_ble_gap_adv_data_set(this->_advData, this->_advDataLen, srData, srDataLen);
+}
+
+
 void nRF51822::begin(unsigned char advertisementDataSize,
                       BLEEirData *advertisementData,
                       unsigned char scanDataSize,
@@ -188,44 +234,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
   sd_ble_gap_ppcp_set(&gap_conn_params);
   sd_ble_gap_tx_power_set(0);
 
-  unsigned char srData[31];
-  unsigned char srDataLen = 0;
-
-  this->_advDataLen = 0;
-
-  // flags
-  this->_advData[this->_advDataLen + 0] = 2;
-  this->_advData[this->_advDataLen + 1] = 0x01;
-  this->_advData[this->_advDataLen + 2] = 0x06;
-
-  this->_advDataLen += 3;
-
-  if (advertisementDataSize && advertisementData) {
-    for (int i = 0; i < advertisementDataSize; i++) {
-      this->_advData[this->_advDataLen + 0] = advertisementData[i].length + 1;
-      this->_advData[this->_advDataLen + 1] = advertisementData[i].type;
-      this->_advDataLen += 2;
-
-      memcpy(&this->_advData[this->_advDataLen], advertisementData[i].data, advertisementData[i].length);
-
-      this->_advDataLen += advertisementData[i].length;
-    }
-  }
-
-  if (scanDataSize && scanData) {
-    for (int i = 0; i < scanDataSize; i++) {
-      srData[srDataLen + 0] = scanData[i].length + 1;
-      srData[srDataLen + 1] = scanData[i].type;
-      srDataLen += 2;
-
-      memcpy(&srData[srDataLen], scanData[i].data, scanData[i].length);
-
-      srDataLen += scanData[i].length;
-      _hasScanData = true;
-    }
-  }
-
-  sd_ble_gap_adv_data_set(this->_advData, this->_advDataLen, srData, srDataLen);
+  updateAdvertisementData(advertisementDataSize, advertisementData, scanDataSize, scanData);
   sd_ble_gap_appearance_set(0);
 
   for (int i = 0; i < numLocalAttributes; i++) {

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -95,6 +95,7 @@ class nRF51822 : public BLEDevice
     unsigned char                     _advData[31];
     unsigned char                     _advDataLen;
     bool                              _hasScanData;
+    ble_gap_evt_adv_report_t*         _scanResult;
     BLECharacteristic*                _broadcastCharacteristic;
 
     uint16_t                          _connectionHandle;

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -61,6 +61,11 @@ class nRF51822 : public BLEDevice
                 BLERemoteAttribute** remoteAttributes,
                 unsigned char numRemoteAttributes);
 
+    virtual void updateAdvertisementData(unsigned char advertisementDataSize,
+                BLEEirData *advertisementData,
+                unsigned char scanDataSize,
+                BLEEirData *scanData);
+
     virtual void poll();
 
     virtual void end();

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -67,6 +67,9 @@ class nRF51822 : public BLEDevice
 
     virtual bool setTxPower(int txPower);
     virtual void startAdvertising();
+    virtual void stopAdvertising();
+    virtual void startScanning();
+    virtual void stopScanning();
     virtual void disconnect();
 
     virtual bool updateCharacteristicValue(BLECharacteristic& characteristic);

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -100,7 +100,6 @@ class nRF51822 : public BLEDevice
     unsigned char                     _advData[31];
     unsigned char                     _advDataLen;
     bool                              _hasScanData;
-    ble_gap_evt_adv_report_t*         _scanResult;
     BLECharacteristic*                _broadcastCharacteristic;
 
     uint16_t                          _connectionHandle;

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -91,6 +91,7 @@ class nRF51822 : public BLEDevice
 
     unsigned char                     _advData[31];
     unsigned char                     _advDataLen;
+    bool                              _hasScanData;
     BLECharacteristic*                _broadcastCharacteristic;
 
     uint16_t                          _connectionHandle;


### PR DESCRIPTION
Amazing library, saved me a lot of work when trying to get the BBC micro:bit up and running for a student. Thanks!

That being said, I'm currently looking into broadcast-based mesh applications, and I need observer support for these (not a full-scale central role, but at least receiving advertisements). I hacked together a couple of control functions and wanted your opinion on 

- if this an addition to the library you'd want to integrate (maybe difficult, I guess the nRF8001 doesn't support scanning at all)
- if you have any suggestions how to properly handle the scan results - I'm currently thinking to just have a `uint8_t* getScanResult()` method that's supposed to be called after `poll()` and will return the most recent result, or NULL.

Best, Florian