### PR TITLE
Implement BLEBoolCharacteristic

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -26,6 +26,7 @@ BLEConstantCharacteristic	KEYWORD1
 BLEFixedLengthCharacteristic	KEYWORD1
 BLEProgmemConstantCharacteristic	KEYWORD1
 
+BLEBoolCharacteristic	KEYWORD1
 BLECharCharacteristic	KEYWORD1
 BLEUnsignedCharCharacteristic	KEYWORD1
 BLEShortCharacteristic	KEYWORD1

--- a/src/BLETypedCharacteristics.cpp
+++ b/src/BLETypedCharacteristics.cpp
@@ -3,6 +3,10 @@
 
 #include "BLETypedCharacteristics.h"
 
+BLEBoolCharacteristic::BLEBoolCharacteristic(const char* uuid, unsigned char properties) :
+  BLETypedCharacteristic<bool>(uuid, properties) {
+}
+
 BLECharCharacteristic::BLECharCharacteristic(const char* uuid, unsigned char properties) :
   BLETypedCharacteristic<char>(uuid, properties) {
 }


### PR DESCRIPTION
Hi Sandeep,

It seems that BLEBoolCharacteristic is missing an implementation, and isn't in "keywords.txt", yet is in the BLETypedCharacteristics header and referenced in the API.md. This is a tiny patch to add it in.