### PR TITLE
Allow attribute table size to be changed via #define

### DIFF
--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -43,6 +43,10 @@ uint32_t sd_ble_gatts_value_set(uint16_t handle, uint16_t offset, uint16_t* cons
 
 #define BLE_STACK_EVT_MSG_BUF_SIZE       (sizeof(ble_evt_t) + (GATT_MTU_SIZE_DEFAULT))
 
+#ifndef BLE_GATTS_ATTR_TAB_SIZE
+  #define BLE_GATTS_ATTR_TAB_SIZE BLE_GATTS_ATTR_TAB_SIZE_DEFAULT
+#endif
+
 nRF51822::nRF51822() :
   BLEDevice(),
 
@@ -132,7 +136,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
 
   memset(&enableParams, 0, sizeof(ble_enable_params_t));
   enableParams.common_enable_params.vs_uuid_count   = 10;
-  enableParams.gatts_enable_params.attr_tab_size    = BLE_GATTS_ATTR_TAB_SIZE_DEFAULT;
+  enableParams.gatts_enable_params.attr_tab_size    = BLE_GATTS_ATTR_TAB_SIZE;
   enableParams.gatts_enable_params.service_changed  = 1;
   enableParams.gap_enable_params.periph_conn_count  = 1;
   enableParams.gap_enable_params.central_conn_count = 0;
@@ -143,7 +147,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
   ble_enable_params_t enableParams = {
       .gatts_enable_params = {
           .service_changed = true,
-          .attr_tab_size = BLE_GATTS_ATTR_TAB_SIZE_DEFAULT
+          .attr_tab_size = BLE_GATTS_ATTR_TAB_SIZE
       }
   };
 


### PR DESCRIPTION
Minor change which makes it possible to easily increase the size of the GATT attribute table size. If you try to add too many attributes then the latest ones just seem to disappear and aren't usable, the solution being to increase the size of the attribute table (which will also require more RAM for the SoftDevice, and less for application).

If you increase just the size of the table then the BLE stack will silently fail to load because BLEPeripheral isn't checking the status code from `sd_ble_enable`, which would report `NRF_ERROR_NO_MEM` if it was checked. This can be fixed by tweaking the `MEMORY` values in the linker script for the particular board.

With this PR's change the quick and easy way to allow more attributes is to simply edit the linker script for the target board and then update `boards.txt` to include `-DBLE_GATTS_ATTR_TAB_SIZE`.

A larger change (can add to this PR if preferred) would be to check the status code of `sd_ble_enable` and in case of `NRF_ERROR_NO_MEM` and debug being enabled, send to serial the suggested start of RAM to use in the linker script (`sd_ble_enable` replaces the value in `app_ram_base` with the suggested value).