### PR TITLE
allow advertising updates at runtime

### DIFF
--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -65,6 +65,11 @@ class BLEDevice
                 BLERemoteAttribute** /*remoteAttributes*/,
                 unsigned char /*numRemoteAttributes*/) { }
 
+    virtual void updateAdvertisementData(unsigned char /*advertisementDataSize*/,
+                BLEEirData * /*advertisementData*/,
+                unsigned char /*scanDataSize*/,
+                BLEEirData * /*scanData*/) { }
+
     virtual void poll() { }
 
     virtual void end() { }

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -68,11 +68,8 @@ BLEPeripheral::~BLEPeripheral() {
   }
 }
 
-void BLEPeripheral::begin() {
+unsigned char BLEPeripheral::updateAdvertismentData() {
   unsigned char advertisementDataSize = 0;
-
-  BLEEirData advertisementData[3];
-  BLEEirData scanData;
 
   scanData.length = 0;
 
@@ -131,6 +128,11 @@ void BLEPeripheral::begin() {
     memcpy(scanData.data, this->_localName, scanData.length);
   }
 
+  return advertisementDataSize;
+}
+
+void BLEPeripheral::begin() {
+
   if (this->_localAttributes == NULL) {
     this->initLocalAttributes();
   }
@@ -158,6 +160,7 @@ void BLEPeripheral::begin() {
     this->addRemoteAttribute(this->_remoteServicesChangedCharacteristic);
   }
 
+  int advertisementDataSize = updateAdvertismentData();
   this->_device->begin(advertisementDataSize, advertisementData,
                         scanData.length > 0 ? 1 : 0, &scanData,
                         this->_localAttributes, this->_numLocalAttributes,

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -206,6 +206,14 @@ void BLEPeripheral::setBondStore(BLEBondStore& bondStore) {
   this->_device->setBondStore(bondStore);
 }
 
+void BLEPeripheral::startAdvertising() {
+  int advertisementDataSize = updateAdvertismentData();
+  this->_device->updateAdvertisementData(
+      advertisementDataSize, advertisementData,
+      scanData.length > 0 ? 1 : 0, &scanData);
+  this->_device->startAdvertising();
+}
+
 void BLEPeripheral::setDeviceName(const char* deviceName) {
   this->_deviceNameCharacteristic.setValue(deviceName);
 }

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -126,6 +126,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
   private:
     void initLocalAttributes();
+    unsigned char updateAdvertismentData();
 
   private:
     BLEDevice*                     _device;
@@ -158,6 +159,9 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
     BLECentral                     _central;
     BLEPeripheralEventHandler      _eventHandlers[4];
+
+    BLEEirData                     advertisementData[3];
+    BLEEirData                     scanData;
 };
 
 #endif

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -80,6 +80,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     void setConnectable(bool connectable);
     void setBondStore(BLEBondStore& bondStore);
 
+    void startAdvertising();
 
     void setDeviceName(const char* deviceName);
     void setAppearance(unsigned short appearance);

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -81,6 +81,52 @@ nRF51822::~nRF51822() {
   this->end();
 }
 
+void nRF51822::updateAdvertisementData(unsigned char advertisementDataSize,
+                      BLEEirData *advertisementData,
+                      unsigned char scanDataSize,
+                      BLEEirData *scanData)
+{
+  unsigned char srData[31];
+  unsigned char srDataLen = 0;
+
+  this->_advDataLen = 0;
+
+  // flags
+  this->_advData[this->_advDataLen + 0] = 2;
+  this->_advData[this->_advDataLen + 1] = 0x01;
+  this->_advData[this->_advDataLen + 2] = 0x06;
+
+  this->_advDataLen += 3;
+
+  if (advertisementDataSize && advertisementData) {
+    for (int i = 0; i < advertisementDataSize; i++) {
+      this->_advData[this->_advDataLen + 0] = advertisementData[i].length + 1;
+      this->_advData[this->_advDataLen + 1] = advertisementData[i].type;
+      this->_advDataLen += 2;
+
+      memcpy(&this->_advData[this->_advDataLen], advertisementData[i].data, advertisementData[i].length);
+
+      this->_advDataLen += advertisementData[i].length;
+    }
+  }
+
+  if (scanDataSize && scanData) {
+    for (int i = 0; i < scanDataSize; i++) {
+      srData[srDataLen + 0] = scanData[i].length + 1;
+      srData[srDataLen + 1] = scanData[i].type;
+      srDataLen += 2;
+
+      memcpy(&srData[srDataLen], scanData[i].data, scanData[i].length);
+
+      srDataLen += scanData[i].length;
+      _hasScanData = true;
+    }
+  }
+
+  sd_ble_gap_adv_data_set(this->_advData, this->_advDataLen, srData, srDataLen);
+}
+
+
 void nRF51822::begin(unsigned char advertisementDataSize,
                       BLEEirData *advertisementData,
                       unsigned char scanDataSize,
@@ -187,44 +233,7 @@ void nRF51822::begin(unsigned char advertisementDataSize,
   sd_ble_gap_ppcp_set(&gap_conn_params);
   sd_ble_gap_tx_power_set(0);
 
-  unsigned char srData[31];
-  unsigned char srDataLen = 0;
-
-  this->_advDataLen = 0;
-
-  // flags
-  this->_advData[this->_advDataLen + 0] = 2;
-  this->_advData[this->_advDataLen + 1] = 0x01;
-  this->_advData[this->_advDataLen + 2] = 0x06;
-
-  this->_advDataLen += 3;
-
-  if (advertisementDataSize && advertisementData) {
-    for (int i = 0; i < advertisementDataSize; i++) {
-      this->_advData[this->_advDataLen + 0] = advertisementData[i].length + 1;
-      this->_advData[this->_advDataLen + 1] = advertisementData[i].type;
-      this->_advDataLen += 2;
-
-      memcpy(&this->_advData[this->_advDataLen], advertisementData[i].data, advertisementData[i].length);
-
-      this->_advDataLen += advertisementData[i].length;
-    }
-  }
-
-  if (scanDataSize && scanData) {
-    for (int i = 0; i < scanDataSize; i++) {
-      srData[srDataLen + 0] = scanData[i].length + 1;
-      srData[srDataLen + 1] = scanData[i].type;
-      srDataLen += 2;
-
-      memcpy(&srData[srDataLen], scanData[i].data, scanData[i].length);
-
-      srDataLen += scanData[i].length;
-      _hasScanData = true;
-    }
-  }
-
-  sd_ble_gap_adv_data_set(this->_advData, this->_advDataLen, srData, srDataLen);
+  updateAdvertisementData(advertisementDataSize, advertisementData, scanDataSize, scanData);
   sd_ble_gap_appearance_set(0);
 
   for (int i = 0; i < numLocalAttributes; i++) {

--- a/src/nRF51822.h
+++ b/src/nRF51822.h
@@ -61,6 +61,11 @@ class nRF51822 : public BLEDevice
                 BLERemoteAttribute** remoteAttributes,
                 unsigned char numRemoteAttributes);
 
+    virtual void updateAdvertisementData(unsigned char advertisementDataSize,
+                BLEEirData *advertisementData,
+                unsigned char scanDataSize,
+                BLEEirData *scanData);
+
     virtual void poll();
 
     virtual void end();


### PR DESCRIPTION
I have a usecase where I want to update the advertisement data while the system is running. A hacky solution is to simply call `begin()` again, but that essentially resets the SoC and also leaks memory. I've refactored the advertisement code so it can be called independently using `startAdvertising()`.

Best, Florian