### PR TITLE
be explicit about compatible architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=An Arduino library for creating custom BLE peripherals.
 paragraph=Supports nRF8001 and nRF51822 based boards/shields
 category=Communication
 url=https://github.com/sandeepmistry/arduino-BLEPeripheral
-architectures=*
+architectures=nRF5,avr,samd,sam
 includes=BLEPeripheral.h


### PR DESCRIPTION
This library is conflicting with the ESP32's BLE library because of `architectures=*`.  Setting architectures explicitly lets me compile for both nRF52 (RedBear BLE Nano 2) and ESP32.

I'm unsure of the Teensy arch, or if it even uses library.properties, so this may need a bit of guidance.