### PR TITLE
Add value_type member to BLETypedCharacteristic

### DIFF
--- a/src/BLETypedCharacteristic.h
+++ b/src/BLETypedCharacteristic.h
@@ -21,6 +21,8 @@ template<typename T> class BLETypedCharacteristic : public BLEFixedLengthCharact
 
     bool setValueBE(T value);
     T valueBE();
+    
+    typedef T value_type;
 
   private:
     T byteSwap(T value);


### PR DESCRIPTION
Simple change that adds a typedef named `value_type` to `BLETypedCharacteristic`. This pattern is common in the STL, and it's nice because especially in C++11 you can easily get the type of a variable with `decltype`, and then get access to the value type.

Example usage (and reason I added it):

```c++
static_assert(sizeof(BLEShortCharacteristic::value_type) == 2, "Short must be 2 bytes");
```