### PR TITLE
Fix wheel report

### DIFF
--- a/src/BLEMouse.cpp
+++ b/src/BLEMouse.cpp
@@ -27,10 +27,11 @@ static const PROGMEM unsigned char descriptorValue[] = {
   0x05, 0x01,           //     USAGE_PAGE (Generic Desktop)
   0x09, 0x30,           //     USAGE (X)
   0x09, 0x31,           //     USAGE (Y)
+  0x09, 0x38,           //     USAGE (WHEEL)                  // Added wheel
   0x15, 0x81,           //     LOGICAL_MINIMUM (-127)
   0x25, 0x7F,           //     LOGICAL_MAXIMUM (127)
   0x75, 0x08,           //     REPORT_SIZE (8)
-  0x95, 0x02,           //     REPORT_COUNT (2)
+  0x95, 0x03,           //     REPORT_COUNT (3)               // Changed to 3
   0x81, 0x06,           //     INPUT (Data,Var,Rel)
   0xC0,                 //   END_COLLECTION
   0xC0                  // END COLLECTION


### PR DESCRIPTION
Wheel value is not ignored now. Without this fix I was not able to scroll using `BLEMouse::move`. This code was taken from Nordic's "ble_app_hids_mouse" example