### PR TITLE
Add raw BLE peripheral event management

### DIFF
--- a/API.md
+++ b/API.md
@@ -141,6 +141,33 @@ void blePeripheralEventHandler(BLECentral& central) {
  * event - ```BLEConnected``` or ```BLEDisconnected```
  * eventHandler - function callback for event
 
+ 
+### Set raw event handler callbacks
+```c
+void setRawEventHandler(BLEPeripheralRawEventHandler rawEventHandler);
+
+// callback signature
+void blePeripheralRawEventHandler(int eventId, const void* event);
+```
+
+Callback example (for a nRF51822)
+```c
+#include <BLEPeripheral.h>
+#include <ble.h>
+
+// ...
+
+void blePeripheralRawEventHandler(int eventId, const void* event) {
+  // Handling a specific event id unandled by BLEPeripheral.
+  if(eventId == BLE_GAP_EVT_ADV_REPORT) {
+	  // Casting into a BLE event
+	  ble_evt_t* evt = (ble_evt_t*)event;
+	  // ...
+  }
+}
+```
+
+ 
 ## Actions
 
 ### Disconnect

--- a/src/BLEDevice.h
+++ b/src/BLEDevice.h
@@ -23,6 +23,8 @@ class BLEDevice;
 class BLEDeviceEventListener
 {
   public:
+    virtual void BLERawEvent(int eventId, const void* event);
+
     virtual void BLEDeviceConnected(BLEDevice& /*device*/, const unsigned char* /*address*/) { }
     virtual void BLEDeviceDisconnected(BLEDevice& /*device*/) { }
     virtual void BLEDeviceBonded(BLEDevice& /*device*/) { }

--- a/src/BLEPeripheral.cpp
+++ b/src/BLEPeripheral.cpp
@@ -25,6 +25,7 @@ BLEPeripheral::BLEPeripheral(unsigned char req, unsigned char rdy, unsigned char
   _manufacturerData(NULL),
   _manufacturerDataLength(0),
   _localName(NULL),
+  _rawEventHandler(NULL),
 
   _localAttributes(NULL),
   _numLocalAttributes(0),
@@ -263,6 +264,10 @@ void BLEPeripheral::setEventHandler(BLEPeripheralEvent event, BLEPeripheralEvent
   }
 }
 
+void BLEPeripheral::setRawEventHandler(BLEPeripheralRawEventHandler rawEventHandler) {
+    this->_rawEventHandler = rawEventHandler;
+}
+
 bool BLEPeripheral::characteristicValueChanged(BLECharacteristic& characteristic) {
   return this->_device->updateCharacteristicValue(characteristic);
 }
@@ -309,6 +314,11 @@ bool BLEPeripheral::canUnsubscribeRemoteCharacteristic(BLERemoteCharacteristic& 
 
 bool BLEPeripheral::unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic) {
   return this->_device->unsubcribeRemoteCharacteristic(characteristic);
+}
+
+void BLEPeripheral::BLERawEvent(int eventId, const void* event) {
+    if(this->_rawEventHandler)
+      this->_rawEventHandler(eventId, event);
 }
 
 void BLEPeripheral::BLEDeviceConnected(BLEDevice& /*device*/, const unsigned char* address) {

--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -53,6 +53,7 @@ enum BLEPeripheralEvent {
 };
 
 typedef void (*BLEPeripheralEventHandler)(BLECentral& central);
+typedef void (*BLEPeripheralRawEventHandler) (int eventId, const void* event);
 
 
 class BLEPeripheral : public BLEDeviceEventListener,
@@ -94,6 +95,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
     bool connected();
 
     void setEventHandler(BLEPeripheralEvent event, BLEPeripheralEventHandler eventHandler);
+    void setRawEventHandler(BLEPeripheralRawEventHandler rawEventHandler);
 
   protected:
     bool characteristicValueChanged(BLECharacteristic& characteristic);
@@ -109,6 +111,8 @@ class BLEPeripheral : public BLEDeviceEventListener,
     bool subscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic);
     bool canUnsubscribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic);
     bool unsubcribeRemoteCharacteristic(BLERemoteCharacteristic& characteristic);
+
+    virtual void BLERawEvent(int eventId, const void* event);
 
     virtual void BLEDeviceConnected(BLEDevice& device, const unsigned char* address);
     virtual void BLEDeviceDisconnected(BLEDevice& device);
@@ -158,6 +162,7 @@ class BLEPeripheral : public BLEDeviceEventListener,
 
     BLECentral                     _central;
     BLEPeripheralEventHandler      _eventHandlers[4];
+    BLEPeripheralRawEventHandler   _rawEventHandler;
 };
 
 #endif

--- a/src/nRF51822.cpp
+++ b/src/nRF51822.cpp
@@ -529,6 +529,10 @@ void nRF51822::poll() {
   ble_evt_t* bleEvt = (ble_evt_t*)evtBuf;
 
   if (sd_ble_evt_get((uint8_t*)evtBuf, &evtLen) == NRF_SUCCESS) {
+
+    if(this->_eventListener)
+      this->_eventListener->BLERawEvent(bleEvt->header.evt_id, bleEvt);
+
     switch (bleEvt->header.evt_id) {
       case BLE_EVT_TX_COMPLETE:
 #ifdef NRF_51822_DEBUG

--- a/src/nRF8001.cpp
+++ b/src/nRF8001.cpp
@@ -806,6 +806,9 @@ void nRF8001::poll() {
   if (lib_aci_event_get(&this->_aciState, &this->_aciData)) {
     aci_evt_t* aciEvt = &this->_aciData.evt;
 
+    if(this->_eventListener)
+      this->_eventListener->BLERawEvent(aciEvt->evt_opcode, aciEvt);
+
     switch(aciEvt->evt_opcode) {
       /**
       As soon as you reset the nRF8001 you will get an ACI Device Started Event
@@ -1451,6 +1454,9 @@ void nRF8001::waitForSetupMode()
     if (lib_aci_event_get(&this->_aciState, &this->_aciData)) {
       aci_evt_t* aciEvt = &this->_aciData.evt;
 
+      if(this->_eventListener)
+        this->_eventListener->BLERawEvent(aciEvt->evt_opcode, aciEvt);
+
       switch(aciEvt->evt_opcode) {
         case ACI_EVT_DEVICE_STARTED: {
           switch(aciEvt->params.device_started.device_mode) {
@@ -1502,6 +1508,9 @@ void nRF8001::sendSetupMessage(hal_aci_data_t* data, bool withCrc)
   while (!setupMsgSent) {
     if (lib_aci_event_get(&this->_aciState, &this->_aciData)) {
       aci_evt_t* aciEvt = &this->_aciData.evt;
+
+      if(this->_eventListener)
+        this->_eventListener->BLERawEvent(aciEvt->evt_opcode, aciEvt);
 
       switch(aciEvt->evt_opcode) {
         case ACI_EVT_CMD_RSP: {


### PR DESCRIPTION
This pull request add the possibility to subscribe to raw events. Useful if you want to handle specific events that are not handled in BLEPeripheral.

I implemented the changes that was discussed in pull request #120.

Tested and work well with nRF51822, should also work with nRF8001 but I can't test it.