### PR TITLE
Add broadcast support for longer uuids

### DIFF
--- a/src/BLEPeripheral.h
+++ b/src/BLEPeripheral.h
@@ -84,7 +84,13 @@ class BLEPeripheral : public BLEDeviceEventListener,
     void setDeviceName(const char* deviceName);
     void setAppearance(unsigned short appearance);
 
+    /**
+     * @brief  Add local services, characteristics and descriptors. Characteristics are assigned to the last added service.
+     */
     void addAttribute(BLELocalAttribute& attribute);
+    /**
+     * @brief  Add local services, characteristics and descriptors. Characteristics are assigned to the last added service.
+     */
     void addLocalAttribute(BLELocalAttribute& localAttribute);
     void addRemoteAttribute(BLERemoteAttribute& remoteAttribute);
 


### PR DESCRIPTION
The existing implementation supports 16 bit UUIDs for broadcasts.
The Bluetooth spec also allows to broadcast with UUIDs of length 32 bit and 128 bit.

[Core Specifications](https://www.bluetooth.com/specifications/bluetooth-core-specification/)
-> [Core Specification Supplement, revision: v9](https://www.bluetooth.org/docman/handlers/DownloadDoc.ashx?doc_id=480305)
-> Chapter 1.11.2

Thanks for reviewing this pull request.